### PR TITLE
fix: open external links in another tab

### DIFF
--- a/src/components/education-channel/index.tsx
+++ b/src/components/education-channel/index.tsx
@@ -1,6 +1,7 @@
 import type { IconComponent } from 'utils/typings/types'
 
-import { Flex, Text, Link } from '@vtex/brand-ui'
+import Link from 'next/link'
+import { Flex, Text } from '@vtex/brand-ui'
 
 import ArrowRightIcon from 'public/icons/arrow-right-icon'
 
@@ -23,24 +24,26 @@ const EducationChannel = ({
 }: props) => {
   return (
     <Link href={link}>
-      <Flex sx={styles.channelBox}>
-        <Icon className="channelIcon" sx={styles.channelIcon} />
-        <Text className="channelTitle" sx={styles.channelTitle}>
-          {title}
-        </Text>
-        <Text className="channelDescription" sx={styles.channelDescription}>
-          {description}
-        </Text>
-        <Flex>
-          <Text className="channelLinkText" sx={styles.channelLinkText}>
-            {textLink}
+      <a target="_blank">
+        <Flex sx={styles.channelBox}>
+          <Icon className="channelIcon" sx={styles.channelIcon} />
+          <Text className="channelTitle" sx={styles.channelTitle}>
+            {title}
           </Text>
-          <ArrowRightIcon
-            className="channelArrow"
-            sx={styles.channelArrowIcon}
-          />
+          <Text className="channelDescription" sx={styles.channelDescription}>
+            {description}
+          </Text>
+          <Flex>
+            <Text className="channelLinkText" sx={styles.channelLinkText}>
+              {textLink}
+            </Text>
+            <ArrowRightIcon
+              className="channelArrow"
+              sx={styles.channelArrowIcon}
+            />
+          </Flex>
         </Flex>
-      </Flex>
+      </a>
     </Link>
   )
 }

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -29,7 +29,12 @@ const links = [
 const Footer = () => (
   <FooterLanding>
     {links.map((link, index) => (
-      <FooterLanding.Link sx={styles.footerLinks} key={index} href={link.to()}>
+      <FooterLanding.Link
+        sx={styles.footerLinks}
+        key={index}
+        href={link.to()}
+        target="_blank"
+      >
         {link.message}
       </FooterLanding.Link>
     ))}


### PR DESCRIPTION
#### What is the purpose of this pull request?

To make links to external pages open in new tabs

#### What problem is this solving?

Currently, links to external pages in the application open on the same tab. The expected behavior is for them to open in new tabs

#### How should this be manually tested?

Documented [here](https://www.notion.so/vtexhandbook/Alterar-cliques-para-links-externos-ao-devportal-para-serem-abertos-em-outra-aba-d5fed8acee8a4fb4a8852034cf174cb3)

Visit [this page](https://deploy-preview-8--xenodochial-shockley-a99d82.netlify.app/) and try clicking on:

- Feedback link in the header component
- Cards in the Education Channels section of the landing page
- Links in the footer component

They should all open in new tabs

#### Screenshots or example usage

Current behavior:

https://user-images.githubusercontent.com/37647055/160154624-65950c46-fbc1-4e16-975e-5a682ab05050.mp4

Expected behavior:

https://user-images.githubusercontent.com/37647055/160154680-dbd26035-ecb9-442e-bcfc-2ee7d1f3e503.mp4

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
