### PR TITLE
fix/add missing shadow effect to Last Updates section cards

### DIFF
--- a/src/components/last-updates-card/styles.ts
+++ b/src/components/last-updates-card/styles.ts
@@ -29,12 +29,14 @@ const cardContainer: SxStyleProp = {
   },
 
   ':active': {
+    'box-shadow': '0px 0px 0px 1px #FFFFFF, 0px 0px 0px 3px #96B2F2',
     '.updateTitle': {
       color: '#0C1522',
     },
   },
 
   ':hover': {
+    'box-shadow': '0px 0px 16px rgba(0, 0, 0, 0.1)',
     '.updateTitle': {
       color: '#000711',
     },


### PR DESCRIPTION
#### What is the purpose of this pull request?

To add missing shadow effects to the cards in the Last Updates section of the landing page

#### What problem is this solving?

The cards in the Last Updates section of the landing page should have shadow effects when hovering and when active

#### How should this be manually tested?

Visit [this page](https://deploy-preview-9--elated-hoover-5c29bf.netlify.app/) and try hovering and clicking the cards on the Last Updates section. You should see a shadow around the cards.

#### Screenshots or example usage

Current behavior:

https://user-images.githubusercontent.com/37647055/160402572-aaa212ca-4909-4b51-ae6b-168077245bc2.mp4

Expected behavior:

https://user-images.githubusercontent.com/37647055/160402598-5944f065-e1f0-439c-9e6f-e9d6385bbd07.mp4

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
