### PR TITLE
style(rapidoc): add tag attributes and css styles to RapiDoc elements

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { AppProps } from 'next/app'
 import { ThemeProvider } from '@vtex/brand-ui'
 
 import 'styles/global.css'
+import 'styles/rapidoc.css'
 import Footer from 'components/footer'
 import Header from 'components/header'
 

--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -6,6 +6,19 @@ interface Props {
 }
 
 const APIPage: NextPage<Props> = ({ slug }) => {
+  const rapidocstyle = {
+    width: '100%',
+    height: '100%',
+    marginTop: '5rem',
+    '--nav-get-color': '#38853C',
+    '--nav-put-color': '#D56A00',
+    '--nav-post-color': '#2978B5',
+    '--nav-delete-color': '#CC3D3D',
+    '--red': '#CC3D3D',
+    '--orange': '#D56A00',
+    '--green': '#2978B5',
+    '--blue': '#38853C',
+  }
   return (
     <>
       <Script
@@ -15,14 +28,29 @@ const APIPage: NextPage<Props> = ({ slug }) => {
 
       <rapi-doc
         spec-url={`/docs/api-reference/${slug}.json`}
+        style={rapidocstyle}
+        fill-request-fields-with-example={true}
         theme="light"
-        show-header={false}
         render-style="focused"
+        bg-color="#FFFFFF"
         nav-bg-color="#FFFFFF"
+        nav-hover-bg-color="#F8F7FC"
+        nav-hover-text-color="#000711"
+        show-method-in-nav-bar={true}
         primary-color="#142032"
         regular-font="VTEX Trust Variable"
-        style={{ height: '100%', width: '100%', marginTop: '5rem' }}
-      />
+        mono-font="VTEX Trust Variable"
+        load-fonts={false}
+        use-path-in-nav-bar={false}
+        nav-text-color="#4A596B"
+        nav-accent-color="#D71D55"
+        nav-item-spacing="relaxed"
+        on-nav-tag-click="expand-collapse"
+        schema-style="table"
+        schema-description-expanded={true}
+        show-info={true}
+        show-header={false}
+      ></rapi-doc>
     </>
   )
 }

--- a/src/styles/rapidoc.css
+++ b/src/styles/rapidoc.css
@@ -1,0 +1,89 @@
+rapi-doc::part(section-navbar) {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 0;
+  background: #FFFFFF;
+  align-self: stretch;
+  margin: 0 15px 0 0;
+}
+
+rapi-doc::part(section-navbar-scroll) {
+  padding: 0px;
+  width: inherit;
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  flex-grow: 0;
+  gap: 11px;
+  overflow-y: scroll;
+  background: #FFFFFF;
+  align-self: stretch;
+}
+
+rapi-doc::part(section-main-content) {
+  background: #FFFFFF;
+  padding: 42px 64px;
+}
+
+rapi-doc::part(section-operations-in-tag) {
+  padding: 24px 0px;
+}
+
+rapi-doc::part(textbox), rapi-doc::part(textbox-param), rapi-doc::part(textarea), rapi-doc::part(textarea-param) {
+  /* Auto layout */
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 8px 8px 12px;
+  position: static;
+  background: rgba(255, 255, 255, 0.0001);
+  border: 1px solid #B9B9B9;
+  box-sizing: border-box;
+  border-radius: 4px;
+  flex: none;
+  align-self: stretch;
+  flex-grow: 0;
+}
+
+rapi-doc::part(btn) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 6px 16px;
+  border-radius: 4px;
+  background: #142032;
+  color: #FFFFFF;
+}
+
+rapi-doc::part(label-operation-path) {
+  display: inline-flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+  position: static;
+  width: auto;
+  height: 28px;
+  left: 0px;
+  top: 0px;
+  border: 1px solid #B9B9B9;
+  border-radius: 0px 4px 4px 0px;
+  margin: 4px 0px;
+}
+
+rapi-doc::part(label-operation-method) {
+  display: inline-flex;
+  flex-direction: row;
+  float: left;
+  align-items: center;
+  padding: 4px 8px;
+  position: static;
+  width: auto;
+  height: 28px;
+  left: 0px;
+  top: 0px;
+  border: 1px solid;
+  border-radius: 4px 0px 0px 4px;
+  margin: 4px 0px;
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

To implement the first styles of [RapiDoc](https://rapidocweb.com/) elements, responsible for rendering the OpenAPI files (documentations) from the Developers Portal (API references).

#### What problem is this solving?

The problem solved by this contribution is the absence of a more specific styling of the OpenAPI renderings with RapiDoc that makes them more close to VTEX patterns and the [designed API Reference defined at Figma](https://www.figma.com/file/Lx6sXdrw9KEvtSEKWttmv8/Developer-Portal?node-id=3722%3A234961). A study of the tool showed that there are 3 possible paths that enable different levels of RapiDoc template styling:

- Adding RapiDoc attributes to rapi-doc tag
  - The RapiDoc attributes represent some parameters that are passed as attributes of the `rapi-doc` tag (used in our React components) and that determine general, structural, visual and interactive characteristics about the rendering of OpenAPI documentation. They are not enough to accomplish the expected design.
- Defining CSS rules to available RapiDoc CSS Parts
  - RapiDoc provided some of its components a `part` attribute that makes those components available to be referenced in a CSS file as a CSS Part. Although this level of styling already gives us a more powerful styling, it does not include all elements of our interest, such as navbar items that don't have a `part` attribute and hence cannot be styled via CSS Parts.
- Applying changes to a clone of RapiDoc source code to generate our own `rapidoc-min.js` package and import it into this repository
  - RapiDoc also gives the user the possibility of cloning their open source repo, aplying changes to a `custom-styles.js` file by referencing CSS tags and classes (although they didn't mention it, it is possible to change other files too) and generating a new RapiDoc build that can be imported into this repository to render OpenAPI with deeper style changes (maybe structural changes too).

The 2 first alternatives were initially applied by this PR to define the basic setup of the OpenAPI rendering, such as the view mode, some navbar behavior and colors, the main font-family, the inputs shape and borders, the REST methods color variables (with overrides) etc. The 3rd alternative will soon be applied to accomplish more flexible changes.
**[Further information about the attributes and other mentioned RapiDoc styling features can be found here at VTEX Lab UFPE taskboard.](https://www.notion.so/vtexhandbook/Estiliza-o-piloto-de-uma-API-reference-OpenAPI-70d078578a3c4276a997e9d369f81585)**


#### How should this be manually tested?

Please read the applied attributes and used CSS parts, if necessary consult the [documentation of this task](https://www.notion.so/vtexhandbook/Estiliza-o-piloto-de-uma-API-reference-OpenAPI-70d078578a3c4276a997e9d369f81585) or RapiDoc ones (referenced in the task docs) to better understand what they represent and visit [this page](https://deploy-preview-33--xenodochial-shockley-a99d82.netlify.app/) to see the resulting styles applied to RapiDoc rendering at `API References -> Catalog.json` (to compare with Figma, access: `-> SKU -> Get SkuId by RefId`). Remember that the main goal of this contribution is to define the basis of the RapiDoc rendering style with the 2 approaches that do not allow applying all the necessary changes to reach the defined design, so check if the chosen values make sense for their purposes.

#### Screenshots or example usage

https://user-images.githubusercontent.com/39717968/166692566-71896488-594e-456f-b715-a807475993bb.mp4


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
