### PR TITLE
Feature/API Guides Documentation Page Layout

### DIFF
--- a/src/components/contributors/index.tsx
+++ b/src/components/contributors/index.tsx
@@ -42,9 +42,15 @@ const Contributors = ({ contributors }: Props) => {
         <Text sx={styles.count}>{contributors.length}</Text>
       </Flex>
 
-      <Grid sx={styles.photosContainer} ref={photosContainer}>
-        {contributors.map((contributor, index) => {
-          if (!showAll && index >= 2 * photosPerRow) return null
+      <Grid
+        sx={styles.photosContainer(
+          showAll
+            ? Math.ceil(contributors.length / photosPerRow)
+            : Math.min(Math.ceil(contributors.length / photosPerRow), 2)
+        )}
+        ref={photosContainer}
+      >
+        {contributors.map((contributor) => {
           return (
             <a key={contributor} href="#">
               <Tooltip label={contributor}>

--- a/src/components/contributors/index.tsx
+++ b/src/components/contributors/index.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { Box, Flex, Grid, IconCaret, Text, Tooltip } from '@vtex/brand-ui'
+
+import { getMessages } from 'utils/get-messages'
+
+import styles from './styles'
+
+interface Props {
+  contributors: string[]
+}
+
+const Contributors = ({ contributors }: Props) => {
+  const messages = getMessages()
+
+  const [showAll, setShowAll] = useState(false)
+  const [pageWidth, setPageWidth] = useState(0)
+  const [photosPerRow, setPhotosPerRow] = useState(0)
+  const photosContainer = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const updatePageWidth = () => {
+      setPageWidth(window.innerWidth)
+    }
+
+    window.addEventListener('resize', updatePageWidth)
+    return () => window.removeEventListener('resize', updatePageWidth)
+  }, [])
+
+  useLayoutEffect(() => {
+    if (photosContainer.current) {
+      const gridStyle = window.getComputedStyle(photosContainer.current)
+      setPhotosPerRow(gridStyle.gridTemplateColumns.split(' ').length)
+    }
+  }, [pageWidth])
+
+  return (
+    <Box>
+      <Flex>
+        <Text sx={styles.title}>
+          {messages['api_guide_documentation_page_contributors.title']}
+        </Text>
+        <Text sx={styles.count}>{contributors.length}</Text>
+      </Flex>
+
+      <Grid sx={styles.photosContainer} ref={photosContainer}>
+        {contributors.map((contributor, index) => {
+          if (!showAll && index >= 2 * photosPerRow) return null
+          return (
+            <a key={contributor} href="#">
+              <Tooltip label={contributor}>
+                <Box sx={styles.photo} />
+              </Tooltip>
+            </a>
+          )
+        })}
+      </Grid>
+
+      {contributors.length > 2 * photosPerRow && (
+        <Flex
+          sx={styles.collapseButton}
+          onClick={() => {
+            setShowAll(!showAll)
+          }}
+        >
+          <Text>
+            {showAll
+              ? messages['api_guide_documentation_page_contributors.toggleText']
+              : `+ ${contributors.length - 2 * photosPerRow} contributors`}
+          </Text>
+          <IconCaret direction={showAll ? 'up' : 'down'} size={24} />
+        </Flex>
+      )}
+    </Box>
+  )
+}
+
+export default Contributors

--- a/src/components/contributors/styles.ts
+++ b/src/components/contributors/styles.ts
@@ -34,7 +34,7 @@ const photosContainer: (rows: number) => SxStyleProp = (rows) => ({
   ],
   overflow: 'hidden',
   maxHeight: `${32 * rows + 8 * (rows - 1)}px`,
-  transition: 'max-height 0.5s ease-in-out',
+  transition: 'max-height 0.3s ease-in-out',
 })
 
 const photo: SxStyleProp = {

--- a/src/components/contributors/styles.ts
+++ b/src/components/contributors/styles.ts
@@ -21,7 +21,7 @@ const count: SxStyleProp = {
   color: '#4A4A4A',
 }
 
-const photosContainer: SxStyleProp = {
+const photosContainer: (rows: number) => SxStyleProp = (rows) => ({
   mt: '16px',
   gap: '8px',
   gridTemplateColumns: [
@@ -32,7 +32,10 @@ const photosContainer: SxStyleProp = {
     '1fr 1fr 1fr 1fr',
     '1fr 1fr 1fr 1fr 1fr',
   ],
-}
+  overflow: 'hidden',
+  maxHeight: `${32 * rows + 8 * (rows - 1)}px`,
+  transition: 'max-height 0.5s ease-in-out',
+})
 
 const photo: SxStyleProp = {
   width: '32px',

--- a/src/components/contributors/styles.ts
+++ b/src/components/contributors/styles.ts
@@ -1,0 +1,67 @@
+import type { SxStyleProp } from '@vtex/brand-ui'
+
+const title: SxStyleProp = {
+  fontSize: ['12px', '12px', '12px', '12px', '12px', '16px'],
+  fontWeight: '400',
+  lineHeight: ['16px', '16px', '16px', '16px', '16px', '18px'],
+  color: '#4A4A4A',
+}
+
+const count: SxStyleProp = {
+  px: '8px',
+  ml: '8px',
+  width: '30px',
+  height: '16px',
+  borderRadius: '24px',
+  backgroundColor: 'muted.4',
+  fontSize: '12px',
+  fontWeight: '400',
+  lineHeight: '16px',
+  textAlign: 'center',
+  color: '#4A4A4A',
+}
+
+const photosContainer: SxStyleProp = {
+  mt: '16px',
+  gap: '8px',
+  gridTemplateColumns: [
+    '1fr 1fr 1fr 1fr',
+    '1fr 1fr 1fr 1fr',
+    '1fr 1fr 1fr 1fr',
+    '1fr 1fr 1fr 1fr',
+    '1fr 1fr 1fr 1fr',
+    '1fr 1fr 1fr 1fr 1fr',
+  ],
+}
+
+const photo: SxStyleProp = {
+  width: '32px',
+  height: '32px',
+  borderRadius: '100%',
+  backgroundColor: 'gainsboro',
+}
+
+const collapseButton: SxStyleProp = {
+  mt: '8px',
+  height: '24px',
+  ...title,
+  color: 'muted.0',
+  cursor: 'pointer',
+  alignItems: 'center',
+
+  ':active': {
+    color: '#0C1522',
+  },
+
+  ':hover': {
+    color: '#000711',
+  },
+}
+
+export default {
+  title,
+  count,
+  photosContainer,
+  photo,
+  collapseButton,
+}

--- a/src/components/markdown-renderer/index.tsx
+++ b/src/components/markdown-renderer/index.tsx
@@ -17,6 +17,9 @@ const components = {
   td: ({ node, ...props }: Component) => (
     <td className={styles.td} {...props} />
   ),
+  img: ({ node, ...props }: Component) => (
+    <img className={styles.img} {...props} />
+  ),
 }
 
 interface Props {

--- a/src/components/markdown-renderer/index.tsx
+++ b/src/components/markdown-renderer/index.tsx
@@ -18,6 +18,7 @@ const components = {
     <td className={styles.td} {...props} />
   ),
   img: ({ node, ...props }: Component) => (
+    // eslint-disable-next-line @next/next/no-img-element
     <img className={styles.img} {...props} />
   ),
 }

--- a/src/components/markdown-renderer/styles.module.css
+++ b/src/components/markdown-renderer/styles.module.css
@@ -5,3 +5,7 @@
 .td {
   border: 1px solid black;
 }
+
+.img {
+  max-width: 100%;
+}

--- a/src/components/sidebar/styles.ts
+++ b/src/components/sidebar/styles.ts
@@ -1,8 +1,14 @@
 import { SxStyleProp } from '@vtex/brand-ui'
 
 const sidebar: SxStyleProp = {
-  display: ['none', 'none', 'none', 'flex'],
+  display: [
+    'none !important',
+    'none !important',
+    'none !important',
+    'flex !important',
+  ],
   width: 'auto',
+  minWidth: 'auto',
   '.active': {
     left: '-276px',
     marginRight: '-120px',
@@ -11,7 +17,6 @@ const sidebar: SxStyleProp = {
 }
 
 const sidebarIcons: SxStyleProp = {
-  display: ['none', 'none', 'none', 'flex'],
   width: '56px',
   height: '692px',
   flexDirection: 'column',

--- a/src/messages/language.json
+++ b/src/messages/language.json
@@ -33,5 +33,7 @@
   "landing_page_footer_feedback.message": "Feedback",
   "landing_page_header_feedback.message": "FeedBack",
   "landing_page_header_docs.message": "Docs",
-  "landing_page_header_searchInput.message": "Search in Developers"
+  "landing_page_header_searchInput.message": "Search in Developers",
+  "api_guide_documentation_page_contributors.title": "Contributors",
+  "api_guide_documentation_page_contributors.toggleText": "See less"
 }

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -2,13 +2,13 @@ import { Box, Flex } from '@vtex/brand-ui'
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next'
 
 import ContextProvider from 'utils/contexts/context'
+import Contributors from 'components/contributors'
 import MarkdownRenderer from 'components/markdown-renderer'
 import Sidebar from 'components/sidebar'
 
 import { getSlugs, readFile } from 'utils/read-files'
 
 import styles from 'styles/documentation-page'
-import Contributors from 'components/contributors'
 
 const markdownDir = '/public/docs/api-guides'
 

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -1,11 +1,14 @@
-import { Box } from '@vtex/brand-ui'
+import { Box, Flex } from '@vtex/brand-ui'
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next'
 
+import ContextProvider from 'utils/contexts/context'
 import MarkdownRenderer from 'components/markdown-renderer'
+import Sidebar from 'components/sidebar'
 
 import { getSlugs, readFile } from 'utils/read-files'
 
 import styles from 'styles/documentation-page'
+import Contributors from 'components/contributors'
 
 const markdownDir = '/public/docs/api-guides'
 
@@ -13,11 +16,23 @@ interface Props {
   content: string
 }
 
+const contributors = 'ABCDEFGHIJKL'.split('')
+
 const DocumentationPage: NextPage<Props> = ({ content }) => {
   return (
-    <Box sx={styles.container}>
-      <MarkdownRenderer markdown={content} />
-    </Box>
+    <ContextProvider>
+      <Flex sx={styles.container}>
+        <Sidebar sectionSelected="API Guides" />
+        <Flex sx={styles.mainContainer}>
+          <Box sx={styles.contentContainer}>
+            <MarkdownRenderer markdown={content} />
+          </Box>
+          <Box sx={styles.rightContainer}>
+            <Contributors contributors={contributors} />
+          </Box>
+        </Flex>
+      </Flex>
+    </ContextProvider>
   )
 }
 

--- a/src/styles/documentation-page.ts
+++ b/src/styles/documentation-page.ts
@@ -1,7 +1,31 @@
 import type { SxStyleProp } from '@vtex/brand-ui'
 
 const container: SxStyleProp = {
-  padding: '5rem 20px 20px',
+  pt: '5rem',
+  width: '100%',
+  backgroundColor: 'white',
 }
 
-export default { container }
+const mainContainer: SxStyleProp = {
+  justifyContent: 'center',
+  width: '100%',
+  pt: '64px',
+}
+
+const contentContainer: SxStyleProp = {
+  width: ['322px', '544px', '544px', '544px', '544px', '720px'],
+}
+
+const rightContainer: SxStyleProp = {
+  ml: '64px',
+  minWidth: 'auto',
+  display: [
+    'none !important',
+    'none !important',
+    'none !important',
+    'none !important',
+    'initial !important',
+  ],
+}
+
+export default { container, mainContainer, contentContainer, rightContainer }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix the layout of the API Guides documentation pages and add the Contributors component.

Documented [here](https://www.notion.so/vtexhandbook/Incrementar-estrutura-de-uma-p-gina-de-API-Guide-d7b904a3afd6412abbac2fad5c8c41a4)

#### What problem is this solving?

The API Guides documentation pages only render markdown files using the MarkdownRenderer component. The pages should also have the sidebar and a component that shows pictures of the contributors of the corresponding article.

#### How should this be manually tested?

Go to [this page](https://deploy-preview-35--elated-hoover-5c29bf.netlify.app/docs/api-guides/billing-options) and [this one](https://deploy-preview-35--elated-hoover-5c29bf.netlify.app/docs/api-guides/clients), try different screen resolutions and check against the designs at [Figma](https://www.figma.com/file/Lx6sXdrw9KEvtSEKWttmv8/Developer-Portal?node-id=2609%3A162549).

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
