### PR TITLE
fix(cypress-workflow): replace npm commands with yarn

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -12,10 +12,10 @@ jobs:
           node-version: 12.x
       - name: Install
         run: |
-          npm ci
+          yarn install --frozen-lockfile
       - name: Build
         run: |
-          npm run build
+          yarn build
       - name: Waiting for 200 from the Netlify Preview
         uses: kamranayub/wait-for-netlify-action@2.0.0
         id: wait-for-netflify-preview

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -12,7 +12,7 @@ jobs:
           node-version: 12.x
       - name: Install
         run: |
-          yarn install --frozen-lockfile
+          yarn install --immutable --immutable-cache --check-cache
       - name: Build
         run: |
           yarn build


### PR DESCRIPTION
#### What is the purpose of this pull request?

To replace the npm commands in the cypress tests workflow with equivalent yarn commands.

#### What problem is this solving?

The use of `yarn` has been stablished as a pattern for the devportal repository, but the cypress workflow is still using `npm` commands, one of which generated an error for another PR evaluation as its commits added a new project dependency via `yarn add`. 

[Further information about this problem can be accessed here.](https://www.notion.so/vtexhandbook/Cria-o-e-configura-o-do-repo-Rapi-Doc-na-nova-organiza-o-vtexdocs-3f507915435e4ed3a4b167af50d86685#a54ee5b48c53465e8720b940a4c7f5f3)

#### How should this be manually tested?

Verify if this PR has passed on the cypress workflow checks, since it already uses the changes introduced by this PR.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
