### PR TITLE
Feature/Tooltip

### DIFF
--- a/src/components/contributors/index.tsx
+++ b/src/components/contributors/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { Box, Flex, Grid, IconCaret, Text, Tooltip } from '@vtex/brand-ui'
+import { Box, Flex, Grid, IconCaret, Text } from '@vtex/brand-ui'
+
+import Tooltip from 'components/tooltip'
 
 import { getMessages } from 'utils/get-messages'
 

--- a/src/components/icons/caret.tsx
+++ b/src/components/icons/caret.tsx
@@ -1,0 +1,20 @@
+import type { IconProps } from '@vtex/brand-ui'
+import { Icon } from '@vtex/brand-ui'
+
+const CaretIcon = (props: IconProps) => (
+  <Icon
+    {...props}
+    width="9"
+    height="4"
+    viewBox="0 0 9 4"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M5.20686 0.707106L8.49976 4L0.499756 4L3.79265 0.707107C4.18317 0.316583 4.81634 0.316582 5.20686 0.707106Z"
+      fill="black"
+    />
+  </Icon>
+)
+
+export default CaretIcon

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from 'react'
+import { Box, Flex, TooltipProps } from '@vtex/brand-ui'
+
+import CaretIcon from 'components/icons/caret'
+
+import styles from './styles'
+
+type Props = Pick<TooltipProps, 'children' | 'label' | 'placement'>
+
+const Tooltip = ({ children, label, placement }: Props) => {
+  const box = useRef<HTMLDivElement>()
+  const [boxWidth, setBoxWidth] = useState(0)
+  const [boxHeight, setBoxHeight] = useState(0)
+  const [boxOffsetLeft, setBoxOffsetLeft] = useState(0)
+  const [boxOffsetTop, setBoxOffsetTop] = useState(0)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (box.current) {
+      setBoxWidth(box.current.clientWidth)
+      setBoxHeight(box.current.clientHeight)
+    }
+  }, [box.current, box.current?.clientWidth, box.current?.clientHeight])
+
+  useEffect(() => {
+    if (box.current) {
+      setBoxOffsetLeft(box.current.offsetLeft)
+      setBoxOffsetTop(box.current.offsetTop)
+    }
+  }, [box.current, box.current?.offsetLeft, box.current?.offsetTop])
+
+  return (
+    <Box>
+      <Box
+        ref={box}
+        onMouseEnter={() => setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+      >
+        {children}
+      </Box>
+      {visible && (
+        <Flex
+          sx={styles.tooltipContainer(
+            placement || 'top',
+            boxWidth,
+            boxHeight,
+            boxOffsetLeft,
+            boxOffsetTop
+          )}
+        >
+          <CaretIcon sx={styles.caret(placement || 'top')} />
+          <Box sx={styles.labelContainer}>{label}</Box>
+        </Flex>
+      )}
+    </Box>
+  )
+}
+
+export default Tooltip

--- a/src/components/tooltip/styles.ts
+++ b/src/components/tooltip/styles.ts
@@ -1,0 +1,90 @@
+import { SxStyleProp } from '@vtex/brand-ui'
+
+type Placement = 'top' | 'right' | 'bottom' | 'left'
+
+const tooltipContainer: (
+  placement: Placement,
+  width: number,
+  height: number,
+  x: number,
+  y: number
+) => SxStyleProp = (placement, width, height, x, y) => {
+  const position = {
+    bottom: {
+      left: `${x + width / 2}px`,
+      top: `${y + height + 3}px`,
+    },
+    left: {
+      left: `${x - 1}px`,
+      top: `${y + height / 2}px`,
+    },
+    top: {
+      left: `${x + width / 2}px`,
+      top: `${y - 3}px`,
+    },
+    right: {
+      left: `${x + width + 1}px`,
+      top: `${y + height / 2}px`,
+    },
+  }
+
+  const translation = {
+    bottom: 'translateX(-50%)',
+    left: 'translateX(-100%) translateY(-50%)',
+    top: 'translateX(-50%) translateY(-100%)',
+    right: 'translateY(-50%)',
+  }
+
+  const direction = {
+    bottom: 'column',
+    left: 'row-reverse',
+    top: 'column-reverse',
+    right: 'row',
+  }
+
+  return {
+    zIndex: '100',
+    position: 'absolute',
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...position[placement],
+    transform: translation[placement],
+    flexDirection: direction[placement],
+  }
+}
+
+const caret: (placement: Placement) => SxStyleProp = (placement) => {
+  const rotation = {
+    bottom: 0,
+    left: 90,
+    top: 180,
+    right: 270,
+  }
+
+  const translation = {
+    bottom: 1,
+    left: 3,
+    top: 1,
+    right: 3,
+  }
+
+  return {
+    width: '8px',
+    height: '4px',
+    minWidth: 'initial',
+    minHeight: 'initial',
+    transform: `rotate(${rotation[placement]}deg) translateY(${translation[placement]}px)`,
+  }
+}
+
+const labelContainer: SxStyleProp = {
+  padding: '4px 8px',
+  borderRadius: '4px',
+  backgroundColor: 'black',
+  color: 'white',
+  fontSize: '12px',
+  fontWeight: '400',
+  lineHeight: '130%',
+}
+
+export default { tooltipContainer, caret, labelContainer }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To add a custom tooltip component to the Developers Portal

#### What problem is this solving?

The contributors component used inside the API Guides pages of the Developers Portal use the tooltip component from brand-ui. But the tooltip in the Developers Portal should have an arrow.

#### How should this be manually tested?

Go to [this page](https://deploy-preview-40--elated-hoover-5c29bf.netlify.app/) and try hovering over the circles in the contributors component. You should see tooltips with the names of the contributors (we are using the first 12 letters of the english alphabet to identify the contributors, so far). Compare those tooltips with the ones at [Figma](https://www.figma.com/file/Lx6sXdrw9KEvtSEKWttmv8/Developer-Portal?node-id=4579%3A246612).

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
