### PR TITLE
build(rapidoc): update rapidoc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.0.2-vtex-9-gbbeac3c"
+      "version": "1.0.3-vtex"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.0.2-vtex"
+      "version": "1.0.2-request-section.0-2-gf8b1570"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.0.2-request-section.0-2-gf8b1570"
+      "version": "1.0.2-vtex-9-gbbeac3c"
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To upgrade the RapiDoc version applied in order to update and style the OpenAPI request section.
#### What problem is this solving?

Inadequate structure and styling to follow [the expected design](https://www.figma.com/file/Lx6sXdrw9KEvtSEKWttmv8/Developer-Portal?node-id=2150%3A138907) for the section showing the request params(with default values).

#### How should this be manually tested?

Check all changes in this [RapiDoc PR](https://github.com/vtexdocs/RapiDoc/pull/2) and compare this [preview](https://deploy-preview-44--elated-hoover-5c29bf.netlify.app/) with the expected design. If you have any change requests, make them at the [request section PR](https://github.com/vtexdocs/RapiDoc/pull/2).

#### Screenshots or example usage

https://user-images.githubusercontent.com/42784961/172213187-defaa7c6-95ee-4510-bd0f-b2882ed51c95.mp4

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
