### PR TITLE
Feature/Header Auth Section

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.0.1-vtex"
+      "version": "1.0.1-auth-page.0"
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To add the correct styles to RapiDoc's authentication page.

Documented [here](https://www.notion.so/vtexhandbook/Estilizar-Header-Auth-RapiDoc-852b4a0e757d4ab19d56bec8ec818f0d)

#### What problem is this solving?

The styles of RapiDoc's authentication page don't match the design of the corresponding section (Header Auth) of the new Developer's Portal, which can be found [here](https://www.figma.com/file/Lx6sXdrw9KEvtSEKWttmv8/Developer-Portal?node-id=3696%3A238901).

#### How should this be manually tested?

Go to [this page](https://deploy-preview-45--elated-hoover-5c29bf.netlify.app/docs/api-reference/catalog#auth) and check against the design at [Figma](https://www.figma.com/file/Lx6sXdrw9KEvtSEKWttmv8/Developer-Portal?node-id=3696%3A238901), keeping in mind only the page title and the API key's labels and inputs were edited, since the page can cease to exist and turn into a section that persists throughout all pages of the same API Reference.

Also, try typing something in the inputs and going to some other page inside the same API Reference. Then, try going back to the authentication page (you can find it by the name of "Authentication" in the left navbar). You should see the previously typed API keys. In other words, the typed API keys should persist through all pages of the same API Reference. Try reproducing the same steps deleting the previously typed API keys.

If you want to make change requests, please do so [here](https://github.com/vtexdocs/RapiDoc/pull/3).

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
