### PR TITLE
fix(font): update brand-ui version with new font

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release": "standard-version"
   },
   "dependencies": {
-    "@vtex/brand-ui": "^0.46.0",
+    "@vtex/brand-ui": "^0.46.1",
     "next": "^12.1.0",
     "node-fetch": "^3.2.4",
     "rapidoc": "^9.2.0",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,8 @@
+html, body, * {
+  font-family: 'VTEX Trust Regular', -apple-system, system-ui,
+    BlinkMacSystemFont, sans-serif !important;
+}
+
 body.modal-open {
   position: fixed;
   overflow-y:scroll;

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,10 +993,10 @@
     "@typescript-eslint/types" "5.14.0"
     eslint-visitor-keys "^3.0.0"
 
-"@vtex/brand-ui@^0.46.0":
-  version "0.46.0"
-  resolved "https://registry.npmjs.org/@vtex/brand-ui/-/brand-ui-0.46.0.tgz"
-  integrity sha512-tMIS5DhX7EScjCwf+bQouc4iCJH/3fL76+qNlkO8NDUmkKI2jSiDVDWTZoEP+MagJ0ghX1a1LnosPwKOj3FG+w==
+"@vtex/brand-ui@^0.46.1":
+  version "0.46.1"
+  resolved "https://registry.yarnpkg.com/@vtex/brand-ui/-/brand-ui-0.46.1.tgz#e08e2517a4369f06abbad5642dddef81eef807c4"
+  integrity sha512-YSjf9H4snG2sEHlofCasmkiu0MMZ9v7PBtaoB0kdV19zdk4R+N6OEu4glbI0o7UjVIiEAkr79aaT4a4dwWG0DQ==
   dependencies:
     "@emotion/core" "^10.0.35"
     "@react-aria/focus" "3.2.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Update the brand-UI version (get the new VTEX Trust font).

#### What problem is this solving?

The Devportal uses an older version of the VTEX Trust font. After the update of the Brand-UI (with the VTEX Trust 1.004), we can import and use the correct version.

#### How should this be manually tested?

Go to [this page](https://deploy-preview-56--elated-hoover-5c29bf.netlify.app/) and check if the font is correct (VTEX Trust Regular) compared with [Figma](https://www.figma.com/file/Lx6sXdrw9KEvtSEKWttmv8/Developer-Portal?node-id=2563%3A140213).

#### Screenshots or example usage

https://user-images.githubusercontent.com/42784961/177777058-6fac6bf5-c588-4f16-9998-79823a281dea.mp4

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
