### PR TITLE
Feature/RapiDoc Breadcrumbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.0.4-vtex-11-ga1d4a86"
+      "version": "1.0.5-vtex"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.0.4-vtex"
+      "version": "1.0.4-vtex-11-ga1d4a86"
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To update RapiDoc version so that we can use the breadcrumbs in the authentication section of the API Reference pages.

#### What problem is this solving?

The RapiDoc version is outdated, it doesn't contain the breadcrumbs component used in the authentication section of the API Reference pages of the Developer's Portal.

#### How should this be manually tested?

Described [here](https://github.com/vtexdocs/RapiDoc/pull/5).

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
