### PR TITLE
fix(sidebar): update the sidebar style

### DIFF
--- a/src/components/sidebar-section/index.tsx
+++ b/src/components/sidebar-section/index.tsx
@@ -1,7 +1,6 @@
 import { Flex, Box, Text } from '@vtex/brand-ui'
 import { useContext, useState } from 'react'
 
-import HelpIcon from 'components/icons/help-icon'
 import SearchIcon from 'components/icons/search-icon'
 import SideBarToggleIcon from 'components/icons/sidebar-toggle-icon'
 import SideBarElements from 'components/sidebar-elements'
@@ -30,10 +29,7 @@ const SidebarSection = ({ title, data }: SidebarSectionProps) => {
         className={sidebarSectionHidden ? 'sidebarHide' : ''}
         sx={styles.sidebarElementsBox}
       >
-        <Text sx={styles.sidebarTitle}>
-          {title}
-          <HelpIcon sx={styles.sidebarHelpIcon} />
-        </Text>
+        <Text sx={styles.sidebarTitle}>{title}</Text>
         <Flex sx={styles.searchBox}>
           <SearchIcon sx={styles.searchIcon} />
           <input

--- a/src/components/sidebar-section/index.tsx
+++ b/src/components/sidebar-section/index.tsx
@@ -36,7 +36,7 @@ const SidebarSection = ({ title, data }: SidebarSectionProps) => {
             style={styles.searchInput}
             className="searchComponent"
             type="text"
-            placeholder="Filter in Title..."
+            placeholder={`Search in ${title}...`}
             value={searchValue}
             onChange={(e) => setSearchValue(e.currentTarget.value)}
           />

--- a/src/components/sidebar/functions.ts
+++ b/src/components/sidebar/functions.ts
@@ -1,0 +1,15 @@
+import { SxStyleProp } from '@vtex/brand-ui'
+
+export const iconTooltipStyle: SxStyleProp = (tooltipState: boolean) => {
+  const iconTooltip: SxStyleProp = {
+    display: [
+      'flex',
+      'flex',
+      'flex',
+      'flex',
+      'flex',
+      tooltipState ? 'flex' : 'none !important',
+    ],
+  }
+  return iconTooltip
+}

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Flex } from '@vtex/brand-ui'
+import { Flex, Text, Box } from '@vtex/brand-ui'
 import Link from 'next/link'
 
 import styles from './styles'
@@ -246,6 +246,7 @@ const Sidebar = ({ sectionSelected }: SideBarSectionState) => {
                   : styles.icon
               }
             />
+            <Text sx={styles.iconTitle}>{iconElement.title}</Text>
           </Flex>
         </a>
       </Link>
@@ -263,6 +264,9 @@ const Sidebar = ({ sectionSelected }: SideBarSectionState) => {
             />
           ))}
         </Flex>
+        <Box sx={styles.sectionDivider}>
+          <hr />
+        </Box>
         <Flex sx={styles.sidebarIconsContainer}>
           {notesIcons.map((notesIconElement) => (
             <SideBarIcon

--- a/src/components/sidebar/styles.ts
+++ b/src/components/sidebar/styles.ts
@@ -9,15 +9,25 @@ const sidebar: SxStyleProp = {
   ],
   width: 'auto',
   minWidth: 'auto',
+  transition: 'all 0.3s ease-in-out',
   '.active': {
     left: '-276px',
     marginRight: '-120px',
     transition: 'all 0.3s ease-in-out',
   },
+  '.iconContainerExpanded': {
+    transition: 'all 0.3s ease-in-out',
+    width: '160px',
+  },
+  '.iconDescriptionExpanded': {
+    display: 'block',
+  },
 }
 
 const sidebarIcons: SxStyleProp = {
   width: ['56px', '56px', '56px', '56px', '56px', '160px'],
+  maxWidth: '160px',
+  transition: 'all 0.3s ease-in-out',
   height: '692px',
   flexDirection: 'column',
   borderRight: '1px solid #E7E9EE',
@@ -26,30 +36,36 @@ const sidebarIcons: SxStyleProp = {
   paddingBottom: '32px',
 }
 
+const linkContainer: SxStyleProp = {
+  minWidth: '100%',
+}
+
 const iconBox: SxStyleProp = {
   mt: ['16px'],
-  width: ['40px', '40px', '40px', '40px', '40px', '144px'],
-  paddingLeft: ['0', '0', '0', '0', '0', '8px'],
-  py: ['0', '0', '0', '0', '0', '10px'],
+  width: '100%',
+  maxWidth: '144px',
+  paddingLeft: ['0', '0', '0', '8px'],
+  paddingRight: ['0', '0', '0', '8px', '8px', '0'],
+  py: ['0', '0', '0', '8px', '8px', '10px'],
   height: '40px',
   borderRadius: '4px',
   alignItems: 'center',
-  justifyContent: [
-    'center',
-    'center',
-    'center',
-    'center',
-    'center',
-    'flex-start',
-  ],
+  justifyContent: 'flex-start',
   background: 'transparent',
   color: 'muted.0',
   cursor: 'pointer',
   ':hover': {
     background: '#F8F7FC',
-    color: '#E31C58',
+    color: '#000711',
     path: {
-      stroke: '#E31C58',
+      stroke: [
+        '#000711',
+        '#000711',
+        '#000711',
+        '#000711',
+        '#000711',
+        '#4A596B',
+      ],
     },
   },
 }
@@ -63,8 +79,8 @@ const iconBoxActive: SxStyleProp = {
 const sidebarIconsContainer: SxStyleProp = {
   width: '100%',
   flexDirection: 'column',
-  alignItems: ['center', 'center', 'center', 'center', 'center', 'flex-start'],
-  px: ['0', '0', '0', '0', '8px'],
+  alignItems: 'flex-start',
+  px: ['0', '0', '0', '8px'],
 }
 
 const icon: SxStyleProp = {
@@ -89,22 +105,36 @@ const sectionDivider: SxStyleProp = {
 }
 
 const iconTitle: SxStyleProp = {
-  display: ['none', 'none', 'none', 'none', 'none', 'initial'],
+  display: ['none', 'none', 'none', 'none', 'none', 'block'],
+  width: '100%',
   fontSize: '14px',
-  ml: '12px',
+  ml: ['8px', '8px', '8px', '8px', '8px', '12px'],
   whiteSpace: 'nowrap',
   overflowX: 'hidden',
   textOverflow: 'ellipsis',
+}
+
+const iconTooltip: SxStyleProp = {
+  display: [
+    'flex !important',
+    'flex !important',
+    'flex !important',
+    'flex !important',
+    'flex !important',
+    'none !important',
+  ],
 }
 
 export default {
   sidebar,
   sidebarIcons,
   sidebarIconsContainer,
+  linkContainer,
   iconBox,
   icon,
   iconActive,
   iconBoxActive,
   sectionDivider,
   iconTitle,
+  iconTooltip,
 }

--- a/src/components/sidebar/styles.ts
+++ b/src/components/sidebar/styles.ts
@@ -17,10 +17,9 @@ const sidebar: SxStyleProp = {
 }
 
 const sidebarIcons: SxStyleProp = {
-  width: '56px',
+  width: ['56px', '56px', '56px', '56px', '56px', '160px'],
   height: '692px',
   flexDirection: 'column',
-  justifyContent: 'space-between',
   borderRight: '1px solid #E7E9EE',
   background: '#FFFFFF',
   zIndex: '2',
@@ -29,15 +28,26 @@ const sidebarIcons: SxStyleProp = {
 
 const iconBox: SxStyleProp = {
   mt: ['16px'],
-  width: '40px',
+  width: ['40px', '40px', '40px', '40px', '40px', '144px'],
+  paddingLeft: ['0', '0', '0', '0', '0', '8px'],
+  py: ['0', '0', '0', '0', '0', '10px'],
   height: '40px',
   borderRadius: '4px',
   alignItems: 'center',
-  justifyContent: 'center',
+  justifyContent: [
+    'center',
+    'center',
+    'center',
+    'center',
+    'center',
+    'flex-start',
+  ],
   background: 'transparent',
+  color: 'muted.0',
   cursor: 'pointer',
   ':hover': {
     background: '#F8F7FC',
+    color: '#E31C58',
     path: {
       stroke: '#E31C58',
     },
@@ -46,13 +56,15 @@ const iconBox: SxStyleProp = {
 
 const iconBoxActive: SxStyleProp = {
   ...iconBox,
-  background: '#F8F7FC',
+  background: ['#F8F7FC', '#F8F7FC', '#F8F7FC', '#F8F7FC', '#F8F7FC', 'none'],
+  color: '#E31C58',
 }
 
 const sidebarIconsContainer: SxStyleProp = {
   width: '100%',
   flexDirection: 'column',
-  alignItems: 'center',
+  alignItems: ['center', 'center', 'center', 'center', 'center', 'flex-start'],
+  px: ['0', '0', '0', '0', '8px'],
 }
 
 const icon: SxStyleProp = {
@@ -67,6 +79,24 @@ const iconActive: SxStyleProp = {
   },
 }
 
+const sectionDivider: SxStyleProp = {
+  px: '8px',
+  marginTop: '16px',
+  hr: {
+    border: '1px solid #E7E9EE',
+    borderTop: 'none',
+  },
+}
+
+const iconTitle: SxStyleProp = {
+  display: ['none', 'none', 'none', 'none', 'none', 'initial'],
+  fontSize: '14px',
+  ml: '12px',
+  whiteSpace: 'nowrap',
+  overflowX: 'hidden',
+  textOverflow: 'ellipsis',
+}
+
 export default {
   sidebar,
   sidebarIcons,
@@ -75,4 +105,6 @@ export default {
   icon,
   iconActive,
   iconBoxActive,
+  sectionDivider,
+  iconTitle,
 }

--- a/src/components/tooltip/index.tsx
+++ b/src/components/tooltip/index.tsx
@@ -1,17 +1,15 @@
 import { useEffect, useRef, useState } from 'react'
-import { Box, Flex, TooltipProps } from '@vtex/brand-ui'
+import { Box, Flex, TooltipProps, SxStyleProp } from '@vtex/brand-ui'
 
 import CaretIcon from 'components/icons/caret'
 
 import styles from './styles'
-
-// type Props = Pick<TooltipProps, 'children' | 'label' | 'placement'>
-
 interface Props extends Pick<TooltipProps, 'children' | 'label' | 'placement'> {
+  sx?: SxStyleProp
   isCard?: boolean
 }
 
-const Tooltip = ({ children, label, placement, isCard }: Props) => {
+const Tooltip = ({ children, label, placement, sx, isCard }: Props) => {
   const box = useRef<HTMLDivElement>()
   const [boxWidth, setBoxWidth] = useState(0)
   const [boxHeight, setBoxHeight] = useState(0)
@@ -43,6 +41,7 @@ const Tooltip = ({ children, label, placement, isCard }: Props) => {
       {visible && (isCard ?? true) && (
         <Flex
           sx={styles.tooltipContainer(
+            sx,
             placement || 'top',
             boxWidth,
             boxHeight,

--- a/src/components/tooltip/styles.ts
+++ b/src/components/tooltip/styles.ts
@@ -3,12 +3,13 @@ import { SxStyleProp } from '@vtex/brand-ui'
 type Placement = 'top' | 'right' | 'bottom' | 'left'
 
 const tooltipContainer: (
+  sx: SxStyleProp,
   placement: Placement,
   width: number,
   height: number,
   x: number,
   y: number
-) => SxStyleProp = (placement, width, height, x, y) => {
+) => SxStyleProp = (sx, placement, width, height, x, y) => {
   const position = {
     bottom: {
       left: `${x + width / 2}px`,
@@ -43,6 +44,7 @@ const tooltipContainer: (
   }
 
   return {
+    ...sx,
     zIndex: '100',
     position: 'absolute',
     alignItems: 'center',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Update the sidebar style with the new sidebar version in Figma.

#### What problem is this solving?

The sidebar style is outdated. This PR proposes to fix it.

#### How should this be manually tested?

Go to [this page](https://deploy-preview-59--elated-hoover-5c29bf.netlify.app/) and compare it with this [page in Figma](https://www.figma.com/file/Lx6sXdrw9KEvtSEKWttmv8/Developer-Portal?node-id=6005%3A356944). Also, check the correct [prototype flow here](https://www.figma.com/proto/Lx6sXdrw9KEvtSEKWttmv8/Developer-Portal?node-id=6005%3A356944&scaling=min-zoom&page-id=6005%3A350485&starting-point-node-id=6005%3A356944&show-proto-sidebar=1).
- On the sixth breakpoint (1920px), we need to add the section title on the side of the section icon.
- Also, add the hover and active effects in this title.
- Remove the help icon on the title in the sidebar section component.

#### Screenshots or example usage

https://user-images.githubusercontent.com/42784961/178868238-7b90b316-487b-46b9-9883-b28164e6e96e.mp4

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
