### PR TITLE
Fix/release style

### DIFF
--- a/src/components/release-note/functions.tsx
+++ b/src/components/release-note/functions.tsx
@@ -1,0 +1,19 @@
+import { Text } from '@vtex/brand-ui'
+import { getDaysElapsed } from 'utils/get-days-elapsed'
+import { getDate } from 'components/release-section/functions'
+
+import styles from './styles'
+import { getMessages } from 'utils/get-messages'
+
+const messages = getMessages()
+
+export const getReleaseDate = (createdAt: string) => {
+  const daysElapsed = getDaysElapsed(new Date(createdAt))
+  return daysElapsed < 8 ? (
+    <Text sx={styles.releaseDate}>{`${getDaysElapsed(new Date(createdAt))} ${
+      messages['relese-note-days-elapsed']
+    }`}</Text>
+  ) : (
+    getDate(createdAt, false)
+  )
+}

--- a/src/components/release-note/index.tsx
+++ b/src/components/release-note/index.tsx
@@ -4,7 +4,7 @@ import { Flex, Timeline, Text, Box, Button, IconCaret } from '@vtex/brand-ui'
 
 import type { UpdateElement } from 'utils/typings/types'
 import { getAction } from './../last-updates-card/functions'
-import { getDaysElapsed } from './../../utils/get-days-elapsed'
+import { getReleaseDate } from './functions'
 import styles from './styles'
 
 interface DescriptionProps {
@@ -34,12 +34,28 @@ const ReleaseNote = ({
 }: ReleaseNoteProps) => {
   const actionValue = actionType ? getAction(actionType) : null
   const [releaseElementStatus, toggleReleaseElementStatus] = useState(isFirst)
+  const [onHover, setOnHover] = useState(false)
+
+  const handleMouseOver = () => {
+    setOnHover(true)
+  }
+
+  const handleMouseOut = () => {
+    setOnHover(false)
+  }
+
   return (
     <Flex sx={styles.releaseContainer}>
       <Button
         size="regular"
         variant="tertiary"
-        sx={releaseElementStatus ? styles.arrowIconActive : styles.arrowIcon}
+        onMouseOver={handleMouseOver}
+        onMouseLeave={handleMouseOut}
+        sx={
+          releaseElementStatus || onHover
+            ? styles.arrowIconActive
+            : styles.arrowIcon
+        }
         icon={() => (
           <IconCaret
             direction={releaseElementStatus ? 'down' : 'right'}
@@ -51,6 +67,7 @@ const ReleaseNote = ({
         }}
       />
       <Timeline.Event
+        sx={styles.timeLineBar}
         title={<Text sx={styles.actionType}>{actionValue?.title}</Text>}
         icon={
           actionValue ? (
@@ -64,8 +81,10 @@ const ReleaseNote = ({
           <Link href={slug}>
             <a>
               <Text
+                onMouseOver={handleMouseOver}
+                onMouseLeave={handleMouseOut}
                 sx={
-                  releaseElementStatus
+                  releaseElementStatus || onHover
                     ? styles.releaseTitleActive
                     : styles.releaseTitle
                 }
@@ -74,9 +93,7 @@ const ReleaseNote = ({
               </Text>
             </a>
           </Link>
-          <Text sx={styles.releaseDate}>{`${getDaysElapsed(
-            new Date(createdAt)
-          )} days ago`}</Text>
+          {getReleaseDate(createdAt)}
           <Description
             description={description}
             releaseStatus={releaseElementStatus}

--- a/src/components/release-note/styles.ts
+++ b/src/components/release-note/styles.ts
@@ -2,14 +2,6 @@ import { SxStyleProp } from '@vtex/brand-ui'
 
 const releaseContainer: SxStyleProp = {
   mb: ['32px', '48px'],
-  '& > :nth-child(2)': {
-    '& > :first-child': {
-      '& > :nth-child(2)': {
-        width: '1px',
-        borderRadius: '8px',
-      },
-    },
-  },
 }
 
 const actionType: SxStyleProp = {
@@ -64,11 +56,23 @@ const arrowIcon: SxStyleProp = {
   pr: '0px',
   pl: 0,
   color: 'muted.0',
+  ':hover': {
+    color: '#0C1522',
+  },
 }
 
 const arrowIconActive: SxStyleProp = {
   ...arrowIcon,
   color: '#0C1522',
+}
+
+const timeLineBar: SxStyleProp = {
+  '& > :first-of-type': {
+    '& > :nth-of-type(2)': {
+      width: '1px',
+      borderRadius: '8px',
+    },
+  },
 }
 
 export default {
@@ -82,4 +86,5 @@ export default {
   releaseDescription,
   arrowIcon,
   arrowIconActive,
+  timeLineBar,
 }

--- a/src/components/release-section/functions.tsx
+++ b/src/components/release-section/functions.tsx
@@ -1,6 +1,21 @@
 import { Text } from '@vtex/brand-ui'
 import styles from './styles'
 
+const month = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
+
 export const compareDates = (
   currentUpdate: string,
   previousUpdate: string
@@ -14,25 +29,15 @@ export const compareDates = (
   )
 }
 
-export const getDate = (currentUpdate: string) => {
+export const getDate = (currentUpdate: string, dataGroup: boolean) => {
   const current = new Date(currentUpdate)
-  const month = [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-  ]
-
   const monthIndex = current.getMonth()
   const year = current.getFullYear()
+  const day = current.getDate()
 
-  return <Text sx={styles.releaseDate}>{month[monthIndex] + ', ' + year}</Text>
+  return (
+    <Text sx={dataGroup ? styles.releaseDate : styles.releaseCreationDay}>
+      {month[monthIndex] + ', ' + (dataGroup ? year : day)}
+    </Text>
+  )
 }

--- a/src/components/release-section/index.tsx
+++ b/src/components/release-section/index.tsx
@@ -26,9 +26,9 @@ const ReleaseSection = () => {
           <>
             {index > 0
               ? compareDates(release.createdAt, releases[index - 1].createdAt)
-                ? getDate(release.createdAt)
+                ? getDate(release.createdAt, true)
                 : null
-              : getDate(release.createdAt)}
+              : getDate(release.createdAt, true)}
             <ReleaseNote
               key={`${release.slug}`}
               isFirst={index == 0}

--- a/src/components/release-section/styles.tsx
+++ b/src/components/release-section/styles.tsx
@@ -35,10 +35,17 @@ const releaseDate: SxStyleProp = {
   mb: ['16px', '24px'],
 }
 
+const releaseCreationDay: SxStyleProp = {
+  color: 'muted.1',
+  fontSize: ['12px', '16px'],
+  lineHeight: '22px',
+}
+
 export default {
   container,
   sectionTitle,
   sectionSubtitle,
   sectionDivider,
   releaseDate,
+  releaseCreationDay,
 }

--- a/src/messages/language.json
+++ b/src/messages/language.json
@@ -68,5 +68,6 @@
   "vtex_io_page_other_resources_learning_center.description": "The Learning Center contains courses about specific aspects of the IO platform and Store Framework.",
   "vtex_io_page_other_resources_github.description": "VTEX IO open-source apps and documentation are fully stored in the VTEX Apps Organization on GitHub.",
   "vtex_io_page_other_resources_help_center.description": "The Help Center contains beginner tutorials, reference guides and troubleshooting articles about the VTEX Admin panel.",
-  "vtex_io_page_other_resources_support.description": "All clients have access to the services provided by our Technical Support team. These specialists are extensively prepared to give you the best experience possible when solving your tickets. To contact them, you need to open a ticket to VTEX support."
+  "vtex_io_page_other_resources_support.description": "All clients have access to the services provided by our Technical Support team. These specialists are extensively prepared to give you the best experience possible when solving your tickets. To contact them, you need to open a ticket to VTEX support.",
+  "relese-note-days-elapsed": "days ago"
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -83,6 +83,16 @@ export const getIcon = (doc: string) => {
 
 export const releaseData: UpdateElement[] = [
   {
+    slug: 'last-weel-test',
+    title:
+      'If it has been less than a week since the creation of the release note, the date description should inform the number of days elapsed',
+    createdAt: '2022-07-23T18:43:15.322Z',
+    hidden: false,
+    description:
+      'To persist campaign data throughout a user session and avoid providing inconsistent campaign data to Google Analytics, you must add the variable OriginalLocation to your Google Tag Manager (GTM) container and configure your store’s Google Analytics tags.',
+    actionType: 'added',
+  },
+  {
     slug: 'secury-proxy-an-alternative-option',
     title: 'Secure Proxy: An alternative option for card payment integrations',
     createdAt: '2022-05-14T18:43:15.322Z',


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the release date logic and add the hover behavior on the title/arrow.

#### What problem is this solving?

When the user hovers over the release note card title/arrow, the component doesn't behave as expected

#### How should this be manually tested?

Go to this page and check :
- If the release note was created less than a week ago, the data format should be `'{daysElapsed} days ago'`.
- If the release note was created over a week, the date format should be `'{Month}, {day}'`.
- The behavior on hover of the title/arrow of the release card (when it's collapsed). If you put your mouse on hover of either one, the color of both needs to change to `'#0C1522'`.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
