### PR TITLE
refactor: switch from Rapidoc to Rapidoc-mini

### DIFF
--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -1,16 +1,15 @@
+import Sidebar from 'components/sidebar'
+import { Flex } from '@vtex/brand-ui'
+
 import Script from 'next/script'
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next'
 
+import styles from 'styles/documentation-page'
 interface Props {
   slug: string
 }
-
+//<rapi-doc-mini spec-url={`/docs/api-reference/${slug}.json`} />
 const APIPage: NextPage<Props> = ({ slug }) => {
-  const rapidocstyle = {
-    width: '100%',
-    height: '100%',
-    marginTop: '5rem',
-  }
   return (
     <>
       <Script
@@ -19,31 +18,25 @@ const APIPage: NextPage<Props> = ({ slug }) => {
         strategy="beforeInteractive"
       />
 
-      <rapi-doc
-        spec-url={`/docs/api-reference/${slug}.json`}
-        style={rapidocstyle}
-        fill-request-fields-with-example={true}
-        theme="light"
-        render-style="focused"
-        bg-color="#FFFFFF"
-        nav-bg-color="#FFFFFF"
-        nav-hover-bg-color="#F8F7FC"
-        nav-hover-text-color="#000711"
-        show-method-in-nav-bar={true}
-        primary-color="#142032"
-        regular-font="VTEX Trust Variable"
-        mono-font="VTEX Trust Variable"
-        load-fonts={false}
-        use-path-in-nav-bar={false}
-        nav-text-color="#4A596B"
-        nav-accent-color="#D71D55"
-        nav-item-spacing="relaxed"
-        on-nav-tag-click="expand-collapse"
-        schema-style="table"
-        schema-description-expanded={true}
-        show-info={true}
-        show-header={false}
-      ></rapi-doc>
+      <Flex sx={styles.container}>
+        <Sidebar sectionSelected="API Reference" />
+        <rapi-doc-mini
+          spec-url={`/docs/api-reference/${slug}.json`}
+          match-paths="get /api/catalog_system/pvt/products/GetProductAndSkuIds"
+          paths-expanded={true}
+          layout="column"
+          fill-request-fields-with-example={true}
+          theme="light"
+          bg-color="#FFFFFF"
+          primary-color="#142032"
+          regular-font="VTEX Trust Variable"
+          mono-font="VTEX Trust Variable"
+          load-fonts={false}
+          schema-style="table"
+          schema-description-expanded={true}
+          id="the-doc"
+        />
+      </Flex>
     </>
   )
 }

--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -7,9 +7,10 @@ import { GetStaticPaths, GetStaticProps, NextPage } from 'next'
 import styles from 'styles/documentation-page'
 interface Props {
   slug: string
+  matchPath: string
 }
 //<rapi-doc-mini spec-url={`/docs/api-reference/${slug}.json`} />
-const APIPage: NextPage<Props> = ({ slug }) => {
+const APIPage: NextPage<Props> = ({ slug, matchPath }) => {
   return (
     <>
       <Script
@@ -22,7 +23,7 @@ const APIPage: NextPage<Props> = ({ slug }) => {
         <Sidebar sectionSelected="API Reference" />
         <rapi-doc-mini
           spec-url={`/docs/api-reference/${slug}.json`}
-          match-paths="get /api/catalog_system/pvt/products/GetProductAndSkuIds"
+          match-paths={matchPath}
           paths-expanded={true}
           layout="column"
           fill-request-fields-with-example={true}
@@ -62,9 +63,15 @@ export const getStaticPaths: GetStaticPaths = () => {
 }
 
 export const getStaticProps: GetStaticProps = ({ params }) => {
+  const matchPath =
+    params?.slug === 'catalog'
+      ? 'get /api/catalog_system/pvt/products/GetProductAndSkuIds'
+      : 'post /api/checkout/pub/orderForms/simulation'
+
   return {
     props: {
       slug: params?.slug,
+      matchPath: matchPath,
     },
   }
 }

--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -4,6 +4,8 @@ import { Flex } from '@vtex/brand-ui'
 import Script from 'next/script'
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next'
 
+import SidebarContextProvider from 'utils/contexts/sidebar'
+
 import styles from 'styles/documentation-page'
 interface Props {
   slug: string
@@ -19,25 +21,27 @@ const APIPage: NextPage<Props> = ({ slug, matchPath }) => {
         strategy="beforeInteractive"
       />
 
-      <Flex sx={styles.container}>
-        <Sidebar sectionSelected="API Reference" />
-        <rapi-doc-mini
-          spec-url={`/docs/api-reference/${slug}.json`}
-          match-paths={matchPath}
-          paths-expanded={true}
-          layout="column"
-          fill-request-fields-with-example={true}
-          theme="light"
-          bg-color="#FFFFFF"
-          primary-color="#142032"
-          regular-font="VTEX Trust Variable"
-          mono-font="VTEX Trust Variable"
-          load-fonts={false}
-          schema-style="table"
-          schema-description-expanded={true}
-          id="the-doc"
-        />
-      </Flex>
+      <SidebarContextProvider>
+        <Flex sx={styles.container}>
+          <Sidebar sectionSelected="API Reference" />
+          <rapi-doc-mini
+            spec-url={`/docs/api-reference/${slug}.json`}
+            match-paths={matchPath}
+            paths-expanded={true}
+            layout="column"
+            fill-request-fields-with-example={true}
+            theme="light"
+            bg-color="#FFFFFF"
+            primary-color="#142032"
+            regular-font="VTEX Trust Variable"
+            mono-font="VTEX Trust Variable"
+            load-fonts={false}
+            schema-style="table"
+            schema-description-expanded={true}
+            id="the-doc"
+          />
+        </Flex>
+      </SidebarContextProvider>
     </>
   )
 }

--- a/src/tests/cypress/integration/catalog-API-page.spec.js
+++ b/src/tests/cypress/integration/catalog-API-page.spec.js
@@ -2,33 +2,12 @@
 
 describe('Catalog API', () => {
   beforeEach(() => {
-    cy.visit('/docs/api-reference/catalog#overview')
+    cy.visit('/docs/api-reference/catalog')
   })
 
-  it('API search', () => {
-    const typedText = 'Create SKU Service Value'
+  it('Check rapidoc-mini', () => {
+    const title = 'Get Product and SKU IDs'
 
-    cy.getRapidocElement('#nav-bar-search').type(`${typedText}{enter}`)
-
-    cy.getRapidocElement('.nav-scroll').children('div').should('have.length', 5)
-
-    cy.getRapidocElement('.nav-scroll')
-      .children('.nav-bar-tag-and-paths')
-      .should('have.length', 1)
-      .children('div')
-      .should('have.length', 2)
-
-    cy.getRapidocElement('.nav-scroll')
-      .find('.nav-bar-tag-and-paths > div')
-      .eq(0)
-      .should('contain', 'SKU Service Value')
-
-    cy.getRapidocElement('.nav-scroll')
-      .find('.nav-bar-tag-and-paths > div')
-      .eq(1)
-      .contains(typedText)
-      .click()
-
-    cy.getRapidocElement('h2').should('contain', `${typedText}`)
+    cy.get('rapi-doc-mini').shadow().find('.title').should('have.text', title)
   })
 })

--- a/src/tests/cypress/support/commands.js
+++ b/src/tests/cypress/support/commands.js
@@ -23,7 +23,3 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-
-Cypress.Commands.add('getRapidocElement', (selector) => {
-  cy.get('rapi-doc').shadow().find(selector)
-})

--- a/src/utils/typings/typings.d.ts
+++ b/src/utils/typings/typings.d.ts
@@ -11,6 +11,8 @@ declare global {
     interface IntrinsicElements {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       'rapi-doc': any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      'rapi-doc-mini': any
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To switch from Rapidoc to rapidoc-mini.
more details [here](https://www.notion.so/vtexhandbook/Substituir-o-uso-do-Rapidoc-pelo-Rapidoc-mini-020f110ed8bd41df8b682bee8b3424fd).

#### What problem is this solving?

We can handle Rapidoc-mini as a simple component on a page, differently from Rapidoc. This change will allow us to have more freedom to stylize the page. 

#### How should this be manually tested?

You can check the api-reference page with Rapidoc-mini [here](https://deploy-preview-61--elated-hoover-5c29bf.netlify.app/docs/api-reference/catalog).

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
