### PR TITLE
Fix/Breadcrumbs on rapidoc-mini

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.0.5-vtex"
+      "version": "v1.0.5-vtex-2-gdce328e"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "v1.0.5-vtex-2-gdce328e"
+      "version": "1.0.6-vtex"
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To update rapidoc version to reflect the change introduced in [this PR](https://github.com/vtexdocs/RapiDoc/pull/6)

#### What problem is this solving?

When trying to use rapidoc-mini in the Developers Portal, the app throws an error, regarding RapiDoc's breadcrumbs.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
