### PR TITLE
build(rapidoc): update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "v1.0.6-vtex-8-g40617a0"
+      "version": "1.0.7-vtex"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.0.6-vtex"
+      "version": "v1.0.6-vtex-8-g40617a0"
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To upgrade the RapiDoc version in order to update the API references response section according to the expected design.

#### What problem is this solving?

The absence of a response section - which displays possible responses to methods and paths with their respective codes and other attributes - that follows the visual design provided for in figma.

_*NOTE: this contribution only included the restructuring of the response section and the adaptation between available information and the available design project. Future tasks will be destined to improve the modal design._

[Further information about this contribution - such as detailed description, related problems and solutions - can be found here.
](https://www.notion.so/vtexhandbook/Estilizar-Response-section-da-API-reference-df7f70dff349461d9926e68590660902)

#### How should this be manually tested?

[Please access this preview](https://deploy-preview-65--elated-hoover-5c29bf.netlify.app/) link and **check if the response section styling of any API reference respects the provided design and if its modal is working properly** - if you find something to fix please comment directly [in the RapiDoc repo corresponding PR](https://github.com/vtexdocs/RapiDoc/pull/7).

#### Screenshots or example usage

https://user-images.githubusercontent.com/39717968/183747231-b1efef77-68e2-4268-9610-4bcb701b53a2.mp4

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
