### PR TITLE
Chore/update rapidoc and review header (consider modal)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.0.7-vtex-6-g1ac290e"
+      "version": "1.0.7-resp-modal"
     }
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.0.7-resp-modal"
+      "version": "1.0.8-vtex"
     }
   },
   "resolutions": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

- to upgrade the RapiDoc version in order to update the API references response section modal
- to review the recently merged custom behavior of the devportal header when the response modal becomes active / inactive

#### What problem is this solving?

The absence of styling properties - similar to the ones established for the rest of the project - in the modal of the responses section at the API references (solved by updating RapiDoc version in this repo). In addition, this contribution also aims to accept reviews about the behavior of the header according to the modal state ([included by this PR](https://github.com/vtexdocs/devportal/pull/69)).

[Further information and detailed description here](https://www.notion.so/vtexhandbook/Estilizar-reponse-modal-da-API-reference-e79400522c674753be6b367113cbeb2f).

#### How should this be manually tested?

Please [access this deploy preview](https://deploy-preview-74--elated-hoover-5c29bf.netlify.app/) to check whether... (remember to only add review comments related to the devportal changes - header behavior - in this PR, otherwise write them at the [RapiDoc corresponding Pull Request](https://github.com/vtexdocs/RapiDoc/pull/8)):

- The response modal has a fixed header and only its body is scrollable
- The response modal scrollbar is similar to the one used at the dropdown menu in multiple browsers
- The user can't scroll the page when the response modal is active
- The dev. portal header automatically hides when the modal shows up
- The dev. portal header automatically comes up when the modal is closed

As some applied changes may interfere with the behavior of the header with respect to the feedback modal at the API guides, please check if you notice any sort of trouble related to it.

#### Screenshots or example usage

| Goal | Screenshot |
| ----------- | ----------- |
| The response modal has a fixed header and only its body is scrollable  | ![image](https://user-images.githubusercontent.com/39717968/186999242-6ae53945-b22f-4ddf-bbfa-c8b88a7b3e1e.png) |
| The response modal scrollbar is similar to the one used at the dropdown menu in multiple browsers   | ![image](https://user-images.githubusercontent.com/39717968/186999704-97b5f7b3-b99f-4abc-8d50-bce9b93417a1.png) |
| The user can't scroll the page when the response modal is active | ![image](https://user-images.githubusercontent.com/39717968/186999820-0dece593-d538-441a-aa6f-fc9ee1b9a701.png) |
| The dev. portal header automatically hides when the modal shows up | <video src="https://user-images.githubusercontent.com/39717968/186999923-8eca6338-3381-44b6-aebe-5e0ff8e008b6.mp4">  |
| The dev. portal header automatically comes up when the modal is closed | <video src="https://user-images.githubusercontent.com/39717968/186999937-2ed6b58a-aefd-4d6b-9ff0-d18aa6b2788d.mp4"> |


https://user-images.githubusercontent.com/39717968/187000392-d0f5ffef-896b-40f3-a552-36a9b562c2a6.mp4

