### PR TITLE
Chore/update rapidoc mini

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.0.9-vtex"
+      "version": "1.0.9-vtex-5-g4152fcb"
     }
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.0.9-vtex-5-g4152fcb"
+      "version": "1.0.10-vtex"
     }
   },
   "resolutions": {

--- a/src/utils/hooks/useNavigation.ts
+++ b/src/utils/hooks/useNavigation.ts
@@ -3,7 +3,6 @@ import useSWRImmutable from 'swr'
 export default function useNavigation() {
   const fetcher = (url: string) => fetch(url).then((res) => res.json())
   const { data, error } = useSWRImmutable('/api/navigation', fetcher)
-  console.log('useNavigation')
   return {
     data: data,
     isLoading: !error && !data,


### PR DESCRIPTION
#### What is the purpose of this pull request?

To update the rapidoc-mini so it contains all the expected elements (that were already included into the default rapidoc tag, which we replaced by the mini version).

#### What problem is this solving?

The absence of some elements at the API references and related styling problems since we switched from rapidoc to rapidoc-mini.

#### How should this be manually tested?

**(If you have changes requests to make related to changes applied in Rapidoc, please register them [in the Rapidoc corresponding PR thread](https://github.com/vtexdocs/RapiDoc/pull/10))**

[Access this deploy preview](https://deploy-preview-78--elated-hoover-5c29bf.netlify.app/) and check if:
- The method-path div (with copy button upon the path) appears below the API references title
- Rapidoc-mini's default colored borders around the API references are gone
- The font-size and spaces between the API reference description, horizontal separators and its cards are balanced as expected (usually 24px)

This PR also remove some previously added `console.log` statements to the devportal source code.

[Further information about this contribution here.](https://www.notion.so/vtexhandbook/Atualizar-conte-do-Lit-retornado-pelo-rapidoc-mini-para-conter-todos-os-elementos-previstos-no-figma-4ab391115a104bb98a8f8bd05297f698)

#### Screenshots or example usage

| Before | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/39717968/193375844-7875b316-c4f6-4276-9feb-51ebee5125b6.png)  | ![image](https://user-images.githubusercontent.com/39717968/193375871-01d07844-3aba-42e1-b3dd-0a908605d70d.png) |
| ![image](https://user-images.githubusercontent.com/39717968/193376002-ef3f52b8-c5d6-441c-b792-c04f77779643.png)  | ![image](https://user-images.githubusercontent.com/39717968/193376022-efea5e4c-0ab8-4ed8-a57f-727fe39568e5.png) |

