### PR TITLE
Feature/HTML Magic Blocks in Markdown

### DIFF
--- a/src/pages/api/docs.ts
+++ b/src/pages/api/docs.ts
@@ -1,6 +1,6 @@
-import getDocsList from 'utils/getDocsList'
+import getDocsPaths from 'utils/getDocsPaths'
 //eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
   req = req
-  res.status(200).json(await getDocsList())
+  res.status(200).json(await getDocsPaths())
 }

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -74,12 +74,11 @@ const DocumentationPage: NextPage<Props> = ({ serialized }) => {
           return [...headings, { ...item, children: [] }]
         }
 
-        const lastHeading = headings[headings.length - 1] || {
+        const { title, slug, children } = headings[headings.length - 1] || {
           title: '',
           slug: '',
           children: [],
         }
-        const { title, slug, children } = lastHeading
 
         return [
           ...headings.slice(0, -1),
@@ -148,11 +147,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     path
   )
 
-  const noMagicBlocks = await replaceMagicBlocks(gitHubFile)
-  const escapedCurlyBraces = escapeCurlyBraces(noMagicBlocks)
-  const noHTMLBlocks = replaceHTMLBlocks(escapedCurlyBraces)
-
   try {
+    const noMagicBlocks = await replaceMagicBlocks(gitHubFile)
+    const escapedCurlyBraces = escapeCurlyBraces(noMagicBlocks)
+    const noHTMLBlocks = replaceHTMLBlocks(escapedCurlyBraces)
+
     let serialized = await serialize(noHTMLBlocks, {
       parseFrontmatter: true,
       mdxOptions: {
@@ -174,6 +173,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       },
     }
   } catch (error) {
+    console.log('Error:', error)
     return {
       notFound: true,
     }

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -28,6 +28,7 @@ import getNavigation from 'utils/getNavigation'
 import getGithubFile from 'utils/getGithubFile'
 import getDocsPaths from 'utils/getDocsPaths'
 import replaceMagicBlocks from 'utils/replaceMagicBlocks'
+import escapeCurlyBraces from 'utils/escapeCurlyBraces'
 // import getDocsListPreval from 'utils/getDocsList.preval'
 
 import styles from 'styles/documentation-page'
@@ -140,8 +141,10 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     path
   )
 
+  const mdxContent = escapeCurlyBraces(gitHubFile)
+
   try {
-    let serialized = await serialize(await replaceMagicBlocks(gitHubFile), {
+    let serialized = await serialize(await replaceMagicBlocks(mdxContent), {
       parseFrontmatter: true,
       mdxOptions: {
         remarkPlugins: [remarkGFM],

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -141,10 +141,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     path
   )
 
-  const mdxContent = escapeCurlyBraces(gitHubFile)
+  const noMagicBlocks = await replaceMagicBlocks(gitHubFile)
+  const mdxContent = escapeCurlyBraces(noMagicBlocks)
 
   try {
-    let serialized = await serialize(await replaceMagicBlocks(mdxContent), {
+    let serialized = await serialize(mdxContent, {
       parseFrontmatter: true,
       mdxOptions: {
         remarkPlugins: [remarkGFM],

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -29,6 +29,7 @@ import getGithubFile from 'utils/getGithubFile'
 import getDocsPaths from 'utils/getDocsPaths'
 import replaceMagicBlocks from 'utils/replaceMagicBlocks'
 import escapeCurlyBraces from 'utils/escapeCurlyBraces'
+import replaceHTMLBlocks from 'utils/replaceHTMLBlocks'
 // import getDocsListPreval from 'utils/getDocsList.preval'
 
 import styles from 'styles/documentation-page'
@@ -142,10 +143,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   )
 
   const noMagicBlocks = await replaceMagicBlocks(gitHubFile)
-  const mdxContent = escapeCurlyBraces(noMagicBlocks)
+  const escapedCurlyBraces = escapeCurlyBraces(noMagicBlocks)
+  const noHTMLBlocks = replaceHTMLBlocks(escapedCurlyBraces)
 
   try {
-    let serialized = await serialize(mdxContent, {
+    let serialized = await serialize(noHTMLBlocks, {
       parseFrontmatter: true,
       mdxOptions: {
         remarkPlugins: [remarkGFM],

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -140,7 +140,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     }
   }
 
-  const gitHubFile = await getGithubFile(
+  let documentationContent = await getGithubFile(
     'vtexdocs',
     'dev-portal-content',
     'first-docs',
@@ -148,11 +148,13 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   )
 
   try {
-    const noMagicBlocks = await replaceMagicBlocks(gitHubFile)
-    const escapedCurlyBraces = escapeCurlyBraces(noMagicBlocks)
-    const noHTMLBlocks = replaceHTMLBlocks(escapedCurlyBraces)
+    if (path.endsWith('.md')) {
+      documentationContent = escapeCurlyBraces(documentationContent)
+      documentationContent = replaceHTMLBlocks(documentationContent)
+      documentationContent = await replaceMagicBlocks(documentationContent)
+    }
 
-    let serialized = await serialize(noHTMLBlocks, {
+    let serialized = await serialize(documentationContent, {
       parseFrontmatter: true,
       mdxOptions: {
         remarkPlugins: [remarkGFM],

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -156,7 +156,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         rehypePlugins: [
           [rehypeHighlight, { languages: { hljsCurl }, ignoreMissing: true }],
         ],
-        format: 'md',
+        format: 'mdx',
       },
     })
   } catch (error) {

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -1,15 +1,21 @@
 import { useEffect, useState } from 'react'
-import { Box, Flex } from '@vtex/brand-ui'
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next'
 import { PHASE_PRODUCTION_BUILD } from 'next/constants'
 
-import type { Item } from 'components/table-of-contents'
+import { serialize } from 'next-mdx-remote/serialize'
+import { MDXRemoteSerializeResult } from 'next-mdx-remote'
+import remarkGFM from 'remark-gfm'
+import rehypeHighlight from 'rehype-highlight'
+import hljsCurl from 'highlightjs-curl'
+
+import { Box, Flex } from '@vtex/brand-ui'
 
 import APIGuidesIcon from 'components/icons/api-guides-icon'
 import APIReferenceIcon from 'components/icons/api-reference-icon'
 
 import APIGuideContextProvider from 'utils/contexts/api-guide'
 
+import type { Item } from 'components/table-of-contents'
 import Contributors from 'components/contributors'
 import MarkdownRenderer from 'components/markdown-renderer'
 import FeedbackSection from 'components/feedback-section'
@@ -18,30 +24,16 @@ import SeeAlsoSection from 'components/see-also-section'
 import TableOfContents from 'components/table-of-contents'
 
 import { removeHTML } from 'utils/string-utils'
-
-import { serialize } from 'next-mdx-remote/serialize'
-import { MDXRemoteSerializeResult } from 'next-mdx-remote'
-import remarkGFM from 'remark-gfm'
+import getNavigation from 'utils/getNavigation'
+import getGithubFile from 'utils/getGithubFile'
+import getDocsPaths from 'utils/getDocsPaths'
+import replaceMagicBlocks from 'utils/replaceMagicBlocks'
+// import getDocsListPreval from 'utils/getDocsList.preval'
 
 import styles from 'styles/documentation-page'
 
-import getNavigation from 'utils/getNavigation'
-import getGithubFile from 'utils/getGithubFile'
-import getDocsList from 'utils/getDocsList'
-// import getDocsListPreval from 'utils/getDocsList.preval'
+const docsPathsGLOBAL = await getDocsPaths()
 
-import replaceMagicBlocks from 'utils/replaceMagicBlocks'
-
-import rehypeHighlight from 'rehype-highlight'
-import hljsCurl from 'highlightjs-curl'
-
-const DocsListGLOBAL = await getDocsList()
-
-interface Props {
-  content: string
-  serialized: MDXRemoteSerializeResult
-  sidebarfallback: any //eslint-disable-line
-}
 const contributors = 'ABCDEFGHIJKL'.split('')
 
 const documentationCards = [
@@ -59,6 +51,12 @@ const documentationCards = [
     Icon: APIReferenceIcon,
   },
 ]
+
+interface Props {
+  content: string
+  serialized: MDXRemoteSerializeResult
+  sidebarfallback: any //eslint-disable-line
+}
 
 const DocumentationPage: NextPage<Props> = ({ serialized }) => {
   const [headings, setHeadings] = useState<Item[]>([])
@@ -111,7 +109,7 @@ const DocumentationPage: NextPage<Props> = ({ serialized }) => {
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const slugs = Object.keys(await getDocsList())
+  const slugs = Object.keys(await getDocsPaths())
   const paths = slugs.map((slug) => ({
     params: { slug },
   }))
@@ -123,22 +121,18 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const slug = params?.slug as string
-  let DocsList
-  if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD) {
-    DocsList = DocsListGLOBAL
-  } else {
-    DocsList = await getDocsList()
-  }
+  const docsPaths =
+    process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
+      ? docsPathsGLOBAL
+      : await getDocsPaths()
 
-  console.log(slug)
-
-  const path = (DocsList as any)[slug] //eslint-disable-line
+  const path = docsPaths[slug]
   if (!path) {
-    console.log('NOT FOUND')
     return {
       notFound: true,
     }
   }
+
   const gitHubFile = await getGithubFile(
     'vtexdocs',
     'dev-portal-content',
@@ -146,10 +140,8 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     path
   )
 
-  const sidebarfallback = await getNavigation()
-  let serialized
   try {
-    serialized = await serialize(await replaceMagicBlocks(gitHubFile), {
+    let serialized = await serialize(await replaceMagicBlocks(gitHubFile), {
       parseFrontmatter: true,
       mdxOptions: {
         remarkPlugins: [remarkGFM],
@@ -159,19 +151,20 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         format: 'mdx',
       },
     })
+
+    const sidebarfallback = await getNavigation()
+    serialized = JSON.parse(JSON.stringify(serialized))
+
+    return {
+      props: {
+        serialized,
+        sidebarfallback,
+      },
+    }
   } catch (error) {
     return {
       notFound: true,
     }
-  }
-
-  serialized = JSON.parse(JSON.stringify(serialized))
-
-  return {
-    props: {
-      serialized,
-      sidebarfallback,
-    },
   }
 }
 

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -74,7 +74,13 @@ const DocumentationPage: NextPage<Props> = ({ serialized }) => {
           return [...headings, { ...item, children: [] }]
         }
 
-        const { title, slug, children } = headings[headings.length - 1]
+        const lastHeading = headings[headings.length - 1] || {
+          title: '',
+          slug: '',
+          children: [],
+        }
+        const { title, slug, children } = lastHeading
+
         return [
           ...headings.slice(0, -1),
           { title, slug, children: [...children, item] },

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -175,7 +175,9 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       },
     }
   } catch (error) {
-    console.log('Error:', error)
+    console.log('Error while processing', path)
+    console.log(error)
+
     return {
       notFound: true,
     }

--- a/src/utils/escapeCurlyBraces.ts
+++ b/src/utils/escapeCurlyBraces.ts
@@ -38,18 +38,32 @@ const escapeCurlyBraces: (content: string) => string = (content) => {
   if (!correctlyFormattedCodeBlocks(content))
     throw new Error('There are incorrectly formatted code blocks in this file')
 
+  let idx = 0
   let newContent = ''
   let insideCodeBlock = false
+  let insideMagicBlock = false
 
-  for (let i = 0; i < content.length; i++) {
-    if (content.charAt(i) === '{' && !insideCodeBlock) newContent += '\\{'
-    else if (content.charAt(i) === '}' && !insideCodeBlock) newContent += '\\}'
+  while (idx < content.length) {
+    if (content.charAt(idx) === '{' && !insideCodeBlock && !insideMagicBlock)
+      newContent += '\\{'
+    else if (
+      content.charAt(idx) === '}' &&
+      !insideCodeBlock &&
+      !insideMagicBlock
+    )
+      newContent += '\\}'
     else {
-      newContent += content.charAt(i)
-      if (content.charAt(i) === '`') {
-        insideCodeBlock = !insideCodeBlock
+      newContent += content.charAt(idx)
+      if (content.charAt(idx) === '`') insideCodeBlock = !insideCodeBlock
+      else if (content.charAt(idx) === '[') {
+        if (content.substring(idx + 1, idx + 6) === 'block')
+          insideMagicBlock = true
+        else if (content.substring(idx + 1, idx + 7) === '/block')
+          insideMagicBlock = false
       }
     }
+
+    idx++
   }
 
   return newContent

--- a/src/utils/escapeCurlyBraces.ts
+++ b/src/utils/escapeCurlyBraces.ts
@@ -1,0 +1,7 @@
+const escapeCurlyBraces: (content: string) => string = (content) => {
+  return content
+    .replace(/\{\{([a-zA-Z0-9]+)\}\}/g, '\\{\\{$1\\}\\}')
+    .replace(/\{([a-zA-Z0-9]+)\}/g, '\\{$1\\}')
+}
+
+export default escapeCurlyBraces

--- a/src/utils/escapeCurlyBraces.ts
+++ b/src/utils/escapeCurlyBraces.ts
@@ -43,6 +43,12 @@ const escapeCurlyBraces: (content: string) => string = (content) => {
   let insideCodeBlock = false
   let insideMagicBlock = false
 
+  if (content.startsWith('---')) {
+    idx += 3
+    while (content.substring(idx, idx + 3) !== '---') idx++
+    idx += 3
+  }
+
   while (idx < content.length) {
     if (content.charAt(idx) === '{' && !insideCodeBlock && !insideMagicBlock)
       newContent += '\\{'

--- a/src/utils/escapeCurlyBraces.ts
+++ b/src/utils/escapeCurlyBraces.ts
@@ -24,10 +24,12 @@ const correctlyFormattedCodeBlocks: (content: string) => boolean = (
         backtickCount++
       }
 
-      if (backtickCount === 3)
+      if (backtickCount === 3) {
+        if (insideSingleLineCodeBlock) return false
         insideMultiLineCodeBlock = !insideMultiLineCodeBlock
-      else if (backtickCount === 1)
+      } else if (backtickCount === 1 && !insideMultiLineCodeBlock) {
         insideSingleLineCodeBlock = !insideSingleLineCodeBlock
+      }
     }
   }
 

--- a/src/utils/escapeCurlyBraces.ts
+++ b/src/utils/escapeCurlyBraces.ts
@@ -1,13 +1,52 @@
+const correctlyFormattedCodeBlocks: (content: string) => boolean = (
+  content
+) => {
+  let idx = 0
+  let insideMultiLineCodeBlock = false
+  let insideSingleLineCodeBlock = false
+
+  while (idx < content.length) {
+    if (content.charAt(idx) !== '`') {
+      if (insideMultiLineCodeBlock || !insideSingleLineCodeBlock) idx++
+      else if (!/\s/.test(content.charAt(idx))) idx++
+      else {
+        let newLineCount = 0
+        while (idx < content.length && /\s/.test(content.charAt(idx))) {
+          if (content.charAt(idx++) === '\n') newLineCount++
+        }
+
+        if (idx >= content.length || newLineCount > 1) return false
+      }
+    } else {
+      let backtickCount = 0
+      while (idx < content.length && content.charAt(idx) === '`') {
+        idx++
+        backtickCount++
+      }
+
+      if (backtickCount === 3)
+        insideMultiLineCodeBlock = !insideMultiLineCodeBlock
+      else if (backtickCount === 1)
+        insideSingleLineCodeBlock = !insideSingleLineCodeBlock
+    }
+  }
+
+  return !insideMultiLineCodeBlock && !insideSingleLineCodeBlock
+}
+
 const escapeCurlyBraces: (content: string) => string = (content) => {
+  if (!correctlyFormattedCodeBlocks(content))
+    throw new Error('There are incorrectly formatted code blocks in this file')
+
   let newContent = ''
   let insideCodeBlock = false
 
   for (let i = 0; i < content.length; i++) {
-    if (content.charAt(i) == '{' && !insideCodeBlock) newContent += '\\{'
-    else if (content.charAt(i) == '}' && !insideCodeBlock) newContent += '\\}'
+    if (content.charAt(i) === '{' && !insideCodeBlock) newContent += '\\{'
+    else if (content.charAt(i) === '}' && !insideCodeBlock) newContent += '\\}'
     else {
       newContent += content.charAt(i)
-      if (content.charAt(i) == '`') {
+      if (content.charAt(i) === '`') {
         insideCodeBlock = !insideCodeBlock
       }
     }

--- a/src/utils/escapeCurlyBraces.ts
+++ b/src/utils/escapeCurlyBraces.ts
@@ -1,7 +1,19 @@
 const escapeCurlyBraces: (content: string) => string = (content) => {
-  return content
-    .replace(/\{\{([a-zA-Z0-9]+)\}\}/g, '\\{\\{$1\\}\\}')
-    .replace(/\{([a-zA-Z0-9]+)\}/g, '\\{$1\\}')
+  let newContent = ''
+  let insideCodeBlock = false
+
+  for (let i = 0; i < content.length; i++) {
+    if (content.charAt(i) == '{' && !insideCodeBlock) newContent += '\\{'
+    else if (content.charAt(i) == '}' && !insideCodeBlock) newContent += '\\}'
+    else {
+      newContent += content.charAt(i)
+      if (content.charAt(i) == '`') {
+        insideCodeBlock = !insideCodeBlock
+      }
+    }
+  }
+
+  return newContent
 }
 
 export default escapeCurlyBraces

--- a/src/utils/getDocsPaths.ts
+++ b/src/utils/getDocsPaths.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/ban-ts-comment */
-const docsList = {
+const docsPaths: { [slug: string]: string } = {
   'billing-options': 'docs/guides/Getting Started/catalog-overview.md',
 }
 
@@ -20,7 +20,7 @@ async function getGithubTree(org: string, repo: string, ref: string) {
 
 //https://api.github.com/repos/vtexdocs/devportal/commits?path=README.md
 
-export default async function getDocsList() {
+export default async function getDocsPaths() {
   const repoTree = await getGithubTree(
     'vtexdocs',
     'dev-portal-content',
@@ -34,9 +34,9 @@ export default async function getDocsList() {
       const match = path.match(re)
       const filename = match?.groups?.filename
       if (filename) {
-        ;(docsList as any)[filename] = path
+        ;(docsPaths as any)[filename] = path
       }
     }
   })
-  return docsList
+  return docsPaths
 }

--- a/src/utils/replaceHTMLBlocks.ts
+++ b/src/utils/replaceHTMLBlocks.ts
@@ -1,0 +1,52 @@
+import { toCamelCase } from './string-utils'
+
+const HTMLBlockRegex = /<([a-z-]+)(.+?)style="([^"]+)"([^>]*)>(.*?)<\/\1>/g
+const selfClosingHTMLTagRegex = /<(.+?)style="([^"]+)"(.*?)\/>/g
+
+const getStyleObject: (styleValue: string) => string = (styleValue) => {
+  const styleProps = styleValue.split(';')
+  const styles = styleProps.map((styleProp: string) => {
+    if (styleProp.trim() == '') return null
+    const [attribute, value] = styleProp.split(':')
+    return `${toCamelCase(attribute.trim())}: "${value.trim()}"`
+  })
+
+  return `{ ${styles.join(', ')} }`
+}
+
+const HTMLBlockReplacer: (
+  _match: string,
+  tag: string,
+  stylePrefix: string,
+  styleValue: string,
+  styleSuffix: string,
+  blockContent: string
+) => string = (
+  _match,
+  tag,
+  stylePrefix,
+  styleValue,
+  styleSuffix,
+  blockContent
+) => {
+  const styleObject = getStyleObject(styleValue)
+  return `<${tag}${stylePrefix}style={${styleObject}}${styleSuffix}>${blockContent}</${tag}>`
+}
+
+const selfClosingHTMLTagReplacer: (
+  _match: string,
+  stylePrefix: string,
+  styleValue: string,
+  styleSuffix: string
+) => string = (_match, stylePrefix, styleValue, styleSuffix) => {
+  const styleObject = getStyleObject(styleValue)
+  return `<${stylePrefix}style={${styleObject}}${styleSuffix}/>`
+}
+
+const replaceHTMLBlocks: (content: string) => string = (content) => {
+  return content
+    .replace(HTMLBlockRegex, HTMLBlockReplacer)
+    .replace(selfClosingHTMLTagRegex, selfClosingHTMLTagReplacer)
+}
+
+export default replaceHTMLBlocks

--- a/src/utils/replaceHTMLBlocks.ts
+++ b/src/utils/replaceHTMLBlocks.ts
@@ -46,6 +46,7 @@ const selfClosingHTMLTagReplacer: (
 
 const replaceHTMLBlocks: (content: string) => string = (content) => {
   return content
+    .replace(/<>/g, '\\<\\>')
     .replace(/<br>/g, '<br />')
     .replace(/<!--.*?-->/gs, '')
     .replace(HTMLBlockRegex, HTMLBlockReplacer)

--- a/src/utils/replaceHTMLBlocks.ts
+++ b/src/utils/replaceHTMLBlocks.ts
@@ -1,7 +1,7 @@
 import { toCamelCase } from './string-utils'
 
 const HTMLBlockRegex = /<([a-z-]+)(.+?)style="([^"]+)"([^>]*)>(.*?)<\/\1>/g
-const selfClosingHTMLTagRegex = /<(.+?)style="([^"]+)"(.*?)\/>/g
+const selfClosingHTMLTagRegex = /<([a-z-]+)(.+?)style="([^"]+)"(.*?)\/>/g
 
 const getStyleObject: (styleValue: string) => string = (styleValue) => {
   const styleProps = styleValue.split(';')
@@ -35,12 +35,13 @@ const HTMLBlockReplacer: (
 
 const selfClosingHTMLTagReplacer: (
   _match: string,
+  tag: string,
   stylePrefix: string,
   styleValue: string,
   styleSuffix: string
-) => string = (_match, stylePrefix, styleValue, styleSuffix) => {
+) => string = (_match, tag, stylePrefix, styleValue, styleSuffix) => {
   const styleObject = getStyleObject(styleValue)
-  return `<${stylePrefix}style={${styleObject}}${styleSuffix}/>`
+  return `<${tag}${stylePrefix}style={${styleObject}}${styleSuffix}/>`
 }
 
 const replaceHTMLBlocks: (content: string) => string = (content) => {

--- a/src/utils/replaceHTMLBlocks.ts
+++ b/src/utils/replaceHTMLBlocks.ts
@@ -46,6 +46,8 @@ const selfClosingHTMLTagReplacer: (
 
 const replaceHTMLBlocks: (content: string) => string = (content) => {
   return content
+    .replace('<br>', '<br />')
+    .replace(/<!--.*?-->/gs, '')
     .replace(HTMLBlockRegex, HTMLBlockReplacer)
     .replace(selfClosingHTMLTagRegex, selfClosingHTMLTagReplacer)
 }

--- a/src/utils/replaceHTMLBlocks.ts
+++ b/src/utils/replaceHTMLBlocks.ts
@@ -46,7 +46,7 @@ const selfClosingHTMLTagReplacer: (
 
 const replaceHTMLBlocks: (content: string) => string = (content) => {
   return content
-    .replace('<br>', '<br />')
+    .replace(/<br>/g, '<br />')
     .replace(/<!--.*?-->/gs, '')
     .replace(HTMLBlockRegex, HTMLBlockReplacer)
     .replace(selfClosingHTMLTagRegex, selfClosingHTMLTagReplacer)

--- a/src/utils/replaceMagicBlocks.ts
+++ b/src/utils/replaceMagicBlocks.ts
@@ -1,12 +1,10 @@
-// const magicBlockRegex =
-//   /\[block:(?<blockType>[^\]]*)\](?<blockContent>.*)\[\/block\]/gms
 const magicBlockRegex =
   /\[block:(?<Type>[^\]]*)\](?<Content>[^]+?)\[\/block\]/gms
 
-function replacer(match: string, p1: string, p2: string) {
-  switch (p1) {
+function replacer(_match: string, blockType: string, blockContent: string) {
+  switch (blockType) {
     case 'code':
-      const code = JSON.parse(p2).codes[0]
+      const code = JSON.parse(blockContent).codes[0]
       switch (code.language) {
         case 'jsonc':
           code.language = 'json'
@@ -17,24 +15,28 @@ function replacer(match: string, p1: string, p2: string) {
         default:
           break
       }
+
       return '\n```' + code.language + '\n' + code.code + '\n```\n'
-      break
+    case 'html':
+      const html = JSON.parse(blockContent)
+        .html.replace(/"/g, '\\"')
+        .replace(/\n/g, '')
+      return `<div dangerouslySetInnerHTML={{ __html: "${html}" }} />`
 
     case 'image':
-      const image = JSON.parse(p2).images[0].image
+      const image = JSON.parse(blockContent).images[0].image
       return `![${image[1]}](${image[0]})`
 
     case 'api-header':
-      const header = JSON.parse(p2).title
+      const header = JSON.parse(blockContent).title
       return `## ${header}\n`
+
     default:
-      return match
-      break
+      return ''
   }
 }
 
 export default async function replaceMagicBlocks(markdown: string) {
   const replacedMarkdown = markdown.replace(magicBlockRegex, replacer)
-
   return replacedMarkdown
 }

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -1,5 +1,14 @@
 export const removeHTML = (str: string) => str.replace(/<\/?[^>]+>/g, '')
 
+export const capitalizeFirstLetter = (str: string) => {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
+export const toCamelCase = (str: string) => {
+  const [firstWord, ...otherWords] = str.split('-')
+  return `${firstWord}${otherWords.map(capitalizeFirstLetter).join('')}`
+}
+
 export const slugify = (str: string) => {
   return str
     .toLowerCase()

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -20,7 +20,8 @@ export const slugify = (str: string) => {
 type Child = string | { props: { children: Child[] } }
 
 export const childrenToString: (children: Child[]) => string = (children) => {
-  if (Array.isArray(children))
+  if (!children) return ''
+  else if (Array.isArray(children))
     return children
       .map((child) => {
         if (typeof child === 'string') return child


### PR DESCRIPTION
#### What is the purpose of this pull request?

To add support for rendering HTML inside HTML magic blocks inside markdown files.

Documented [here](https://www.notion.so/vtexhandbook/Tratar-block-html-a9ff83362d5d4523ab1882ddb2498f80)

#### What problem is this solving?

Some of the portal's documentation files contains magic blocks of several types. The HTML magic blocks inside those files are being rendered like text.

#### How should this be manually tested?

Go to [this page](https://deploy-preview-81--elated-hoover-5c29bf.netlify.app/docs/api-guides/dev-portal-test) and verify there is a red text that says "A Custom HTML block". This came from this [magic block](https://github.com/vtexdocs/dev-portal-content/blob/a6693ebf0afcf2689021185c3b7b5769ce17cb40/docs/guides/Test/dev-portal-test.md?plain=1#L75). Additionally, you may search for other documentation inside the [dev-portal-content repository](https://github.com/vtexdocs/dev-portal-content/) that contains HTML magic blocks and opening the corresponding pages in this deploy to see if the blocks are being rendered correctly. Here are the slugs of some documentations I found useful when testing (you can access their pages by going to https://deploy-preview-81--elated-hoover-5c29bf.netlify.app/docs/api-guides/[slug]):

- getuser
- login-integration-guide
- payments-integration-payment-provider-framework
- use-master-data-with-orders
- vtex-io-documentation-managing-url-redirects
- starthandling
- external-marketplace-integration-stock-update
- adaptations-and-limitations
- instantpublishing

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
