### PR TITLE
fix: implement handleclick and slugprefix

### DIFF
--- a/src/components/sidebar-elements/index.tsx
+++ b/src/components/sidebar-elements/index.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useContext } from 'react'
 import { Box, Flex, Button, Link, IconCaret } from '@vtex/brand-ui'
-
+import { useRouter } from 'next/router'
 import { SidebarContext } from 'utils/contexts/sidebar'
 import { MethodType } from 'utils/typings/unionTypes'
 import MethodCategory from 'components/method-category'
@@ -31,6 +31,12 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
     toggleSidebarElementStatus,
     openSidebarElement,
   } = useContext(SidebarContext)
+
+  const router = useRouter()
+  const handleClick = (e: { preventDefault: () => void }, path: string) => {
+    e.preventDefault()
+    router.push(`/docs/${slugPrefix}/${path}`)
+  }
 
   const ElementRoot = ({ slug, name, method, children }: SidebarElement) => {
     const isExpandable = children.length > 0
@@ -64,9 +70,10 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
           <Link
             sx={textStyle(activeSidebarElement === slug, isExpandable)}
             target="_self"
-            onClick={() => {
+            onClick={(e: { preventDefault: () => void }) => {
               openSidebarElement(slug)
               setActiveSidebarElement(slug)
+              handleClick(e, slug)
             }}
           >
             {method && (
@@ -92,7 +99,7 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
       sidebarElementStatus.get(slug) ? (
       <Box>
         <SidebarElements
-          slugPrefix={slug}
+          slugPrefix={slugPrefix}
           items={children}
           subItemLevel={subItemLevel + 1}
           key={`${slug}sd`}
@@ -105,7 +112,7 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
     <Box>
       {items?.map((item, index) => {
         const key = String(item.slug) + String(index)
-        const slug = `${slugPrefix || ''}${item.slug}`
+        const slug = `${item.slug}`
 
         return (
           <Fragment key={String(key)}>

--- a/src/components/sidebar-section/index.tsx
+++ b/src/components/sidebar-section/index.tsx
@@ -8,15 +8,24 @@ import SideBarElements from 'components/sidebar-elements'
 import { SidebarContext } from 'utils/contexts/sidebar'
 import type { SidebarElement } from 'components/sidebar-elements'
 
-import type { DocumentationTitle, UpdatesTitle } from 'utils/typings/unionTypes'
+import type {
+  DocumentationTitle,
+  UpdatesTitle,
+  SlugPrefix,
+} from 'utils/typings/unionTypes'
 import styles from './styles'
 import SectionFilter from 'components/sidebar-section-filter'
 export interface SidebarSectionProps {
   documentation: DocumentationTitle | UpdatesTitle
   categories: SidebarElement[]
+  slugPrefix: SlugPrefix
 }
 
-const SidebarSection = ({ documentation, categories }: SidebarSectionProps) => {
+const SidebarSection = ({
+  documentation,
+  categories,
+  slugPrefix,
+}: SidebarSectionProps) => {
   const [searchValue, setSearchValue] = useState('')
   const { sidebarSectionHidden, setSidebarSectionHidden } =
     useContext(SidebarContext)
@@ -91,7 +100,11 @@ const SidebarSection = ({ documentation, categories }: SidebarSectionProps) => {
           />
         )}
         <Box sx={styles.sidebarContainerBody}>
-          <SideBarElements items={filteredResult} subItemLevel={0} />
+          <SideBarElements
+            items={filteredResult}
+            subItemLevel={0}
+            slugPrefix={slugPrefix}
+          />
         </Box>
       </Box>
       <Flex

--- a/src/utils/typings/unionTypes.ts
+++ b/src/utils/typings/unionTypes.ts
@@ -9,6 +9,13 @@ export type DocumentationTitle =
 
 export type UpdatesTitle = 'Release Notes' | 'Documentation Updates'
 
+export type SlugPrefix =
+  | 'api-guides'
+  | 'api-reference'
+  | 'vtex-io'
+  | 'faststore'
+  | 'webOps'
+
 export type ResourceTitle =
   | 'Community'
   | 'Learning Center'


### PR DESCRIPTION
A função `handleClick` foi implementada para atualizar a rota quando um item da sidebar é selecionado.
O arquivo `navigation.json` foi atualizado, incluindo agora o campo `slugPrefix` no mesmo nível de `documentation`. 
```
{
  "navbar": [
    {
      "documentation": "API Guides",
      "slugPrefix": "api-guides",
      "categories": [
(...)
```
A finalidade deste campo é compor a rota dos itens da sidebar da seguinte forma: `router.push(`/docs/${slugPrefix}/${slug}`)`