### PR TITLE
feat(devportal-scraper): add scraper action and command to run locally

### DIFF
--- a/.github/workflows/docsearch-scraper.yml
+++ b/.github/workflows/docsearch-scraper.yml
@@ -15,6 +15,6 @@ jobs:
     - name: Devportal Scraper
       uses: vtexdocs/devportal-docsearch-action@main
       with:
-        algolia_application_id: 'A4TXCBOC74'
+        algolia_application_id: '${{ secrets.ALGOLIA_APP_ID }}'
         algolia_api_key: ${{ secrets.ALGOLIA_WRITE_KEY }}
         file: './configs/scraper_md.json'

--- a/.github/workflows/docsearch-scraper.yml
+++ b/.github/workflows/docsearch-scraper.yml
@@ -1,0 +1,20 @@
+name: Devportal Scraper
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Scraper running
+    steps:
+    - uses: actions/checkout@v2
+    - name: Devportal Scraper
+      uses: vtexdocs/devportal-docsearch-action@main
+      with:
+        algolia_application_id: 'A4TXCBOC74'
+        algolia_api_key: ${{ secrets.ALGOLIA_WRITE_KEY }}
+        file: './configs/scraper_md.json'

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/algolia/scraper_md.json
+++ b/algolia/scraper_md.json
@@ -1,0 +1,32 @@
+{
+  "index_name": "docsearch-scraper-md-files",
+  "start_urls": ["http://elated-hoover-5c29bf.netlify.app/docs/api-guides"],
+  "stop_urls": [],
+  "selectors": {
+    "lvl0": "h1",
+    "lvl1": "h2",
+    "lvl2": "h3",
+    "lvl3": "h4",
+    "lvl4": "h5",
+    "text": "p, .title, li"
+  },
+  "custom_settings": {
+    "separatorsToIndex": "_",
+    "attributesForFaceting": ["doctype"],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type",
+      "doctype"
+    ]
+  },
+  "only_content_level": true,
+  "js_render": true,
+  "js_wait": 10,
+  "use_anchors": true,
+  "conversation_id": ["706181789"],
+  "nb_hits": 4610
+}

--- a/algolia/scraper_openapi.json
+++ b/algolia/scraper_openapi.json
@@ -1,0 +1,32 @@
+{
+  "index_name": "docsearch-scraper-openapi-test",
+  "start_urls": ["https://elated-hoover-5c29bf.netlify.app/docs/api-reference"],
+  "stop_urls": [],
+  "selectors": {
+    "lvl0": "h1",
+    "lvl1": "h2",
+    "lvl2": "h3",
+    "lvl3": "h4",
+    "lvl4": "h5",
+    "text": ".param-name, p, .title, li, span, button, .textarea.request-body-param-user-input"
+  },
+  "custom_settings": {
+    "separatorsToIndex": "_",
+    "attributesForFaceting": ["doctype"],
+    "attributesToRetrieve": [
+      "hierarchy",
+      "content",
+      "anchor",
+      "url",
+      "url_without_anchor",
+      "type",
+      "doctype"
+    ]
+  },
+  "only_content_level": true,
+  "js_render": true,
+  "js_wait": 4,
+  "use_anchors": true,
+  "conversation_id": ["706181789"],
+  "nb_hits": 2
+}

--- a/algolia/scripts/scraper.sh
+++ b/algolia/scripts/scraper.sh
@@ -1,0 +1,59 @@
+#!/bin/sh -l
+set -e
+
+APPLICATION_ID=$1
+API_KEY=$2
+FILE=$3
+
+# remove docsearch-scraper directory
+rm -rf ./docsearch-scraper
+
+
+if [ -e ./.env ]
+then
+  export $(grep "^ALGOLIA_APP_ID\|^ALGOLIA_WRITE_KEY" .env)
+fi
+
+if [ -z "${ALGOLIA_APP_ID}" ] || [ -z "${ALGOLIA_WRITE_KEY}" ]
+then
+  echo "❌ Required keys are missing in your .env file"
+  exit 1
+fi
+
+# build from the main source repository
+git clone https://github.com/vtexdocs/docsearch-scraper.git
+
+cp ./algolia/scraper_md.json ./docsearch-scraper/configs
+cp ./algolia/scraper_openapi.json ./docsearch-scraper/configs
+
+cd docsearch-scraper/
+
+# install specific version of pipenv
+pip3 install pipenv==2018.11.26
+
+# download chromedriver
+
+wget -q https://chromedriver.storage.googleapis.com/106.0.5249.61/chromedriver_linux64.zip
+
+unzip chromedriver_linux64.zip
+chmod +x chromedriver
+
+# create the .env file for docsearch
+echo "APPLICATION_ID=${ALGOLIA_APP_ID}
+API_KEY=${ALGOLIA_WRITE_KEY}
+CHROMEDRIVER_PATH=./chromedriver
+" > .env
+
+PIPENV_VENV_IN_PROJECT=true pipenv install
+
+echo "Update webclient.py"
+cp ./utils/webclient.py ./.venv/lib/python3.6/site-packages/scrapy/core/downloader/
+
+pipenv run ./docsearch run ./configs/scraper_md.json
+
+echo "🚀 Successfully indexed and uploaded the results to Algolia"
+
+cd ..
+
+# remove docsearch-scraper directory
+rm -rf ./docsearch-scraper

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "next lint",
     "postinstall": "husky install",
     "cz-commit": "cz",
-    "release": "standard-version"
+    "release": "standard-version",
+    "index": "chmod +x ./algolia/scripts/scraper.sh && ./algolia/scripts/scraper.sh"
   },
   "dependencies": {
     "@plaiceholder/next": "^2.5.0",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the action to index DevPortal pages on every merged PRs and the possibility to run locally with the shell script.

[:book: Docs (and keys) here](https://www.notion.so/vtexhandbook/Criar-GitHub-action-para-rodar-crawler-6ba5ef9b8ac54798a3f403c2402de7d8)

#### What problem is this solving?

The absence of CI/CD about the reindexing of the app pages.

#### How should this be manually tested?

Check the code and try to run the index command (if you're a Linux user).

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
