### PR TITLE
Feature/Parameters Magic Blocks in Markdown

### DIFF
--- a/src/components/overview-card/index.tsx
+++ b/src/components/overview-card/index.tsx
@@ -49,7 +49,7 @@ const ListOfDocs = ({ docs, seeMore, href }: ListOfDocsProps) => (
     ))}
     {seeMore && (
       <li className={styles.seeMore}>
-        <Link href={href}>
+        <Link href={href} legacyBehavior>
           <a>See more</a>
         </Link>
       </li>

--- a/src/utils/replaceMagicBlocks.ts
+++ b/src/utils/replaceMagicBlocks.ts
@@ -1,3 +1,5 @@
+import { matrixToMarkdownTable } from './string-utils'
+
 const magicBlockRegex =
   /\[block:(?<Type>[^\]]*)\](?<Content>[^]+?)\[\/block\]/gms
 
@@ -30,6 +32,25 @@ function replacer(_match: string, blockType: string, blockContent: string) {
     case 'api-header':
       const header = JSON.parse(blockContent).title
       return `## ${header}\n`
+
+    case 'parameters':
+      const { data, rows, cols } = JSON.parse(blockContent)
+
+      const matrix: string[][] = []
+      for (let i = 0; i <= rows; i++) {
+        const row: string[] = []
+        for (let j = 0; j < cols; j++) row.push('')
+
+        matrix.push(row)
+      }
+
+      for (const key in data) {
+        const [row, col] = key.split('-')
+        if (row === 'h') matrix[0][+col] = data[key]
+        else matrix[+row + 1][+col] = data[key]
+      }
+
+      return matrixToMarkdownTable(matrix)
 
     default:
       return ''

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -33,3 +33,19 @@ export const childrenToString: (children: Child[]) => string = (children) => {
     return childrenToString(children['props']['children'])
   }
 }
+
+export const matrixToMarkdownTable: (matrix: string[][]) => string = (
+  matrix
+) => {
+  const matrixRowToMarkdownTableRow = (matrixRow: string[]) =>
+    `|${matrixRow.map((matrixElement) => ` ${matrixElement} |`).join('')}`
+
+  let table = matrixRowToMarkdownTableRow(matrix[0]) + '\n|'
+  for (let i = 0; i < matrix[0].length; i++) table += ' --- |'
+
+  table += '\n'
+  for (let i = 1; i < matrix.length; i++)
+    table += matrixRowToMarkdownTableRow(matrix[i]) + '\n'
+
+  return table
+}

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -38,7 +38,9 @@ export const matrixToMarkdownTable: (matrix: string[][]) => string = (
   matrix
 ) => {
   const matrixRowToMarkdownTableRow = (matrixRow: string[]) =>
-    `|${matrixRow.map((matrixElement) => ` ${matrixElement} |`).join('')}`
+    `|${matrixRow
+      .map((matrixElement) => ` ${matrixElement.replace(/\n/g, '<br />')} |`)
+      .join('')}`
 
   let table = matrixRowToMarkdownTableRow(matrix[0]) + '\n|'
   for (let i = 0; i < matrix[0].length; i++) table += ' --- |'


### PR DESCRIPTION
#### What is the purpose of this pull request?

To handle parameters magic blocks inside markdown files so that they are rendered as tables.

#### What problem is this solving?

The parameters magic blocks inside markdown files are currently being ignored by the markdown renderer. They should be rendered as tables.

#### How should this be manually tested?

Go to [this page](https://deploy-preview-93--elated-hoover-5c29bf.netlify.app/docs/api-guides/dev-portal-test) and check if [this magic block](https://github.com/vtexdocs/dev-portal-content/blob/a6693ebf0afcf2689021185c3b7b5769ce17cb40/docs/guides/Test/dev-portal-test.md?plain=1#L57) is correctly rendered as a table. Additionally, you may search for other documentations in the [dev-portal-content repository](https://github.com/vtexdocs/dev-portal-content/tree/first-docs) that contain parameters magic blocks and check if those are correctly rendered as tables in their corresponding pages in the devportal website.

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
