### PR TITLE
fix(escapecurlybraces): pass frontmatter to newContent

### DIFF
--- a/src/utils/escapeCurlyBraces.ts
+++ b/src/utils/escapeCurlyBraces.ts
@@ -50,6 +50,7 @@ const escapeCurlyBraces: (content: string) => string = (content) => {
     while (content.substring(idx, idx + 3) !== '---') idx++
     idx += 3
   }
+  newContent = content.substring(0, idx)
 
   while (idx < content.length) {
     if (content.charAt(idx) === '{' && !insideCodeBlock && !insideMagicBlock)


### PR DESCRIPTION
#### What is the purpose of this pull request?

Parsear o frontmatter.

#### What problem is this solving?

O newContent não estava recebendo o frontmatter, e por isso, o título dos guides não estava sendo renderizado.

#### How should this be manually tested?

Acessar qualquer página de guides e verificar se o título é renderizado

#### Screenshots or example usage

|Before|After|
|------|-----|
| ![Screen Shot 2022-12-20 at 10 06 35](https://user-images.githubusercontent.com/60782333/208674358-a3d4893d-58c4-4775-ae62-15e3d94ac76e.png) | ![Screen Shot 2022-12-20 at 10 06 17](https://user-images.githubusercontent.com/60782333/208674303-80c9722f-81bd-4751-b9de-9b84cf97d401.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
