### PR TITLE
build(rapidoc): update rapidoc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.1.0-vtex-2-ge6f50a1"
+      "version": "1.1.0-vtex-6-gfc95ad3"
     }
   },
   "resolutions": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To upgrade the RapiDoc version in order to display the two column layout and implement the communication between RapiDoc sections.

#### What problem is this solving?

It makes easier to test the API since the components will be divided into two columns. And when an input is changed the new value is showed instantly in the code part of the RapiDoc section.

#### How should this be manually tested?

Go to [the preview page](https://deploy-preview-108--elated-hoover-5c29bf.netlify.app/) and check if the layout in the API Reference pages is displayed correctly in all resolutions and if when an input is changed the curl is updated.

Review comments should be added to the [corresponding RapiDoc pull request](https://github.com/vtexdocs/RapiDoc/pull/13).

#### Screenshots or example usage

Further information, screenshots and videos can be found [here](https://www.notion.so/vtexhandbook/Implementar-layout-de-duas-colunas-na-p-gina-de-API-reference-12f10119422a4b8d8d2d86b7a3645b38) and [here](https://www.notion.so/vtexhandbook/Comunicar-estado-das-se-es-OpenAPI-rapidoc-e51d2283131247e0a037abab5d605f1b).

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
