### PR TITLE
Fix/Last Breakpoint

### DIFF
--- a/src/components/breadcrumb/index.tsx
+++ b/src/components/breadcrumb/index.tsx
@@ -14,7 +14,7 @@ const Breadcrumb = ({ breadcumbList }: Props) => {
           <>
             <Text>{item.name}</Text>
             {idx < breadcumbList.length - 1 ? (
-              <IconCaret direction="right" />
+              <IconCaret direction="right" sx={styles.caret} />
             ) : (
               ''
             )}
@@ -25,7 +25,7 @@ const Breadcrumb = ({ breadcumbList }: Props) => {
               {item.name}
             </Link>
             {idx < breadcumbList.length - 1 ? (
-              <IconCaret direction="right" />
+              <IconCaret direction="right" sx={styles.caret} />
             ) : (
               ''
             )}

--- a/src/components/breadcrumb/styles.ts
+++ b/src/components/breadcrumb/styles.ts
@@ -1,7 +1,11 @@
 import type { SxStyleProp } from '@vtex/brand-ui'
 
 const breadcrumb: SxStyleProp = {
+  alignItems: 'center',
   color: '#A1A8B3 !important',
+  mb: ['32px', '32px', '32px', '32px', '32px', '32px', '64px'],
+  fontSize: ['16px', '16px', '16px', '16px', '16px', '16px', '24px'],
+  lineHeight: '18px',
 }
 
 const breadcrumbItem: SxStyleProp = {
@@ -10,4 +14,10 @@ const breadcrumbItem: SxStyleProp = {
     color: '#F71963',
   },
 }
-export default { breadcrumb, breadcrumbItem }
+
+const caret: SxStyleProp = {
+  width: ['16px', '16px', '16px', '16px', '16px', '16px', '32px'],
+  height: ['16px', '16px', '16px', '16px', '16px', '16px', '32px'],
+}
+
+export default { breadcrumb, breadcrumbItem, caret }

--- a/src/components/category-layout/index.tsx
+++ b/src/components/category-layout/index.tsx
@@ -1,11 +1,12 @@
-import styles from './styles.module.css'
+import styles from './styles'
 import type { ReactElement } from 'react'
+import { Box } from '@vtex/brand-ui'
 interface Props {
   children: ReactElement[]
 }
 
 const Layout = ({ children }: Props) => {
-  return <div className={styles.container}>{children}</div>
+  return <Box sx={styles.container}>{children}</Box>
 }
 
 export default Layout

--- a/src/components/category-layout/styles.module.css
+++ b/src/components/category-layout/styles.module.css
@@ -1,7 +1,0 @@
-.container {
-  max-width: 55rem;
-  margin: auto;
-  font-size: 18px;
-  color: #5b6e84;
-  padding: 0 20px 100px 20px;
-}

--- a/src/components/category-layout/styles.ts
+++ b/src/components/category-layout/styles.ts
@@ -1,0 +1,11 @@
+import { SxStyleProp } from '@vtex/brand-ui'
+
+const container: SxStyleProp = {
+  maxWidth: '1080px',
+  margin: 'auto',
+  fontSize: ['18px', '18px', '18px', '18px', '18px', '18px', '28px'],
+  color: '#5B6E84',
+  padding: '0 20px 100px 20px',
+}
+
+export default { container }

--- a/src/components/contributors/styles.ts
+++ b/src/components/contributors/styles.ts
@@ -12,8 +12,8 @@ const titleContainer: SxStyleProp = {
 
 const title: SxStyleProp = {
   fontWeight: '400',
-  fontSize: ['12px', '16px', '16px', '16px', '12px', '16px'],
-  lineHeight: ['16px', '22px', '22px', '22px', '16px', '18px'],
+  fontSize: ['12px', '16px', '16px', '16px', '12px', '16px', '22px'],
+  lineHeight: ['16px', '22px', '22px', '22px', '16px', '18px', '22px'],
   color: '#4A4A4A',
 }
 
@@ -24,46 +24,68 @@ const count: SxStyleProp = {
   height: '16px',
   borderRadius: '24px',
   backgroundColor: 'muted.4',
-  fontSize: '12px',
+  fontSize: ['12px', '12px', '12px', '12px', '12px', '12px', '22px'],
   fontWeight: '400',
   lineHeight: '16px',
   textAlign: 'center',
   color: '#4A4A4A',
 }
 
-const photosContainer: (rows: number) => SxStyleProp = (rows) => ({
-  mt: '16px',
-  gap: '8px',
-  gridTemplateColumns: [
-    '1fr 1fr 1fr 1fr',
-    '1fr 1fr 1fr 1fr 1fr 1fr',
-    '1fr 1fr 1fr 1fr 1fr 1fr',
-    '1fr 1fr 1fr 1fr 1fr 1fr',
-    '1fr 1fr 1fr 1fr',
-    '1fr 1fr 1fr 1fr 1fr',
-  ],
-  overflow: 'hidden',
-  width: [0, 'min-content', 'min-content', 'min-content', '152px', '192px'],
-  maxHeight: `${32 * rows + 8 * (rows - 1)}px`,
-  transition: 'max-height 0.3s ease-in-out',
-})
+const photosContainer: (rows: number) => SxStyleProp = (rows) => {
+  const maxHeight = (photoSize: number, gap: number) =>
+    `${photoSize * rows + gap * (rows - 1)}px`
+  const defaultMaxHeight = maxHeight(32, 8)
+
+  return {
+    mt: ['16px', '16px', '16px', '16px', '16px', '16px', '24px'],
+    gap: ['8px', '8px', '8px', '8px', '8px', '8px', '12px'],
+    gridTemplateColumns: [
+      '1fr 1fr 1fr 1fr',
+      '1fr 1fr 1fr 1fr 1fr 1fr',
+      '1fr 1fr 1fr 1fr 1fr 1fr',
+      '1fr 1fr 1fr 1fr 1fr 1fr',
+      '1fr 1fr 1fr 1fr',
+      '1fr 1fr 1fr 1fr 1fr',
+    ],
+    overflow: 'hidden',
+    width: [
+      0,
+      'min-content',
+      'min-content',
+      'min-content',
+      '152px',
+      '192px',
+      '288px',
+    ],
+    maxHeight: [
+      defaultMaxHeight,
+      defaultMaxHeight,
+      defaultMaxHeight,
+      defaultMaxHeight,
+      defaultMaxHeight,
+      defaultMaxHeight,
+      maxHeight(48, 12),
+    ],
+    transition: 'max-height 0.3s ease-in-out',
+  }
+}
 
 const photo: SxStyleProp = {
-  width: '32px',
-  height: '32px',
+  width: ['32px', '32px', '32px', '32px', '32px', '32px', '48px'],
+  height: ['32px', '32px', '32px', '32px', '32px', '32px', '48px'],
   img: {
-    width: '32px',
-    height: '32px',
+    width: ['32px', '32px', '32px', '32px', '32px', '32px', '48px'],
+    height: ['32px', '32px', '32px', '32px', '32px', '32px', '48px'],
     borderRadius: '100%',
   },
 }
 
 const collapseButton: SxStyleProp = {
-  mt: '8px',
+  mt: ['8px', '8px', '8px', '8px', '8px', '8px', '16px'],
   height: '24px',
   fontWeight: '400',
-  fontSize: ['12px', '12px', '12px', '12px', '12px', '16px'],
-  lineHeight: ['16px', '16px', '16px', '16px', '16px', '18px'],
+  fontSize: ['12px', '12px', '12px', '12px', '12px', '12px', '22px'],
+  lineHeight: ['16px', '16px', '16px', '16px', '16px', '16px', '22px'],
   color: 'muted.0',
   cursor: 'pointer',
   alignItems: 'center',

--- a/src/components/documentation-card/functions.ts
+++ b/src/components/documentation-card/functions.ts
@@ -5,12 +5,12 @@ const cardContainer = (containerType: string) => {
   const containerWidth =
     containerType === 'dropdown'
       ? ['308px', '442px', '444px', '480px']
-      : ['324px', '544px', '544px', '544px', '544px', '720px']
+      : ['324px', '544px', '544px', '544px', '544px', '720px', '1080px']
 
   const textWidth =
     containerType === 'dropdown'
       ? ['276px', '410px', '412px', '432px']
-      : ['276px', '496px', '496px', '496px', '496px', '672px']
+      : ['276px', '496px', '496px', '496px', '496px', '672px', '1032px']
 
   const cardContainer: SxStyleProp = {
     ...styles.cardContainer,
@@ -26,7 +26,9 @@ const cardContainer = (containerType: string) => {
 
 const titleContainer = (containerType: string) => {
   const marginBottom =
-    containerType === 'dropdown' ? ['5px', '5px', '5px', '1px'] : '8px'
+    containerType === 'dropdown'
+      ? ['5px', '5px', '5px', '1px']
+      : ['8px', '8px', '8px', '8px', '8px', '8px', '12px']
 
   const titleContainer: SxStyleProp = {
     ...styles.titleContainer,

--- a/src/components/documentation-card/styles.ts
+++ b/src/components/documentation-card/styles.ts
@@ -1,7 +1,7 @@
 import { SxStyleProp } from '@vtex/brand-ui'
 
 const cardContainer: SxStyleProp = {
-  my: '16px',
+  my: ['16px', '16px', '16px', '16px', '16px', '16px', '24px'],
   padding: '8px',
 
   ':active, :hover': {
@@ -27,26 +27,26 @@ const titleContainer: SxStyleProp = {
 }
 
 const icon: SxStyleProp = {
-  width: '24px',
-  height: '24px',
+  width: ['24px', '24px', '24px', '24px', '24px', '24px', '36px'],
+  height: ['24px', '24px', '24px', '24px', '24px', '24px', '36px'],
 }
 
 const text: SxStyleProp = {
-  fontSize: '16px',
+  fontSize: ['16px', '16px', '16px', '16px', '16px', '16px', '24px'],
+  lineHeight: ['22px', '22px', '22px', '22px', '22px', '22px', '28px'],
   fontWeight: '400',
-  lineHeight: '22px',
   textTransform: 'none',
 }
 
 const title: SxStyleProp = {
   ...text,
-  ml: '8px',
+  ml: ['8px', '8px', '8px', '8px', '8px', '8px', '12px'],
   color: 'muted.0',
 }
 
 const description: SxStyleProp = {
   ...text,
-  ml: '32px',
+  ml: ['32px', '32px', '32px', '32px', '32px', '32px', '48px'],
   color: 'muted.1',
 }
 

--- a/src/components/feedback-section/index.tsx
+++ b/src/components/feedback-section/index.tsx
@@ -31,7 +31,7 @@ const FeedbackSection = () => {
 
   return (
     <Flex sx={styles.container}>
-      <Text>
+      <Text sx={styles.question}>
         {feedback !== undefined
           ? messages['feedback_section.response']
           : messages['feedback_section.question']}

--- a/src/components/feedback-section/styles.ts
+++ b/src/components/feedback-section/styles.ts
@@ -10,6 +10,11 @@ const container: SxStyleProp = {
   marginBlock: '32px',
 }
 
+const question: SxStyleProp = {
+  fontSize: ['16px', '16px', '16px', '16px', '16px', '16px', '22px'],
+  lineHeight: '22px',
+}
+
 const likeContainer: SxStyleProp = {
   paddingBottom: ['16px', '0'],
   borderBottom: ['1px solid #E7E9EE', 'none'],
@@ -19,11 +24,18 @@ const likeContainer: SxStyleProp = {
   justifyContent: ['center', 'initial'],
 }
 
+const icon: SxStyleProp = {
+  width: ['24px', '24px', '24px', '24px', '24px', '24px', '32px'],
+  height: ['24px', '24px', '24px', '24px', '24px', '24px', '32px'],
+}
+
 const likeIcon: SxStyleProp = {
+  ...icon,
   mr: '2px',
 }
 
 const dislikeIcon: SxStyleProp = {
+  ...icon,
   mr: '2px',
   transform: 'rotateX(180deg) rotateY(180deg)',
 }
@@ -53,7 +65,7 @@ const selectedButton: SxStyleProp = {
 const box: SxStyleProp = {
   alignItems: 'center',
   color: 'muted.0',
-  fontSize: '16px',
+  fontSize: ['16px', '16px', '16px', '16px', '16px', '16px', '22px'],
   lineHeight: '22px',
 }
 
@@ -61,13 +73,14 @@ const editContainer: SxStyleProp = {
   ...box,
   ...button,
   ml: ['0', 'auto'],
-  display: 'Flex',
+  display: 'flex',
 }
 
-const editIcon: SxStyleProp = { mr: '4px' }
+const editIcon: SxStyleProp = { ...icon, mr: '4px' }
 
 export default {
   container,
+  question,
   likeContainer,
   likeIcon,
   dislikeIcon,

--- a/src/components/markdown-renderer/index.tsx
+++ b/src/components/markdown-renderer/index.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@vtex/brand-ui'
 import { MDXRemote } from 'next-mdx-remote'
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const MDXRemote2: any = MDXRemote
@@ -10,7 +11,19 @@ interface Props {
 }
 
 const MarkdownRenderer = ({ serialized }: Props) => (
-  <>
+  <Box
+    sx={{
+      fontSize: [
+        'initial',
+        'initial',
+        'initial',
+        'initial',
+        'initial',
+        'initial',
+        '28px',
+      ],
+    }}
+  >
     <Head>
       <link
         rel="stylesheet"
@@ -20,7 +33,7 @@ const MarkdownRenderer = ({ serialized }: Props) => (
       />
     </Head>
     <MDXRemote2 components={components} lazy {...serialized} />
-  </>
+  </Box>
 )
 
 export default MarkdownRenderer

--- a/src/components/see-also-section/styles.ts
+++ b/src/components/see-also-section/styles.ts
@@ -1,12 +1,12 @@
 import { SxStyleProp } from '@vtex/brand-ui'
 
 const seeAlsoContainer: SxStyleProp = {
-  maxWidth: ['324px', '544px', '544px', '544px', '544px', '720px'],
+  maxWidth: ['324px', '544px', '544px', '544px', '544px', '720px', '1080px'],
   mx: ['18px', 'initial'],
 }
 
 const sectionTitle: SxStyleProp = {
-  fontSize: ['18px', '22px'],
+  fontSize: ['18px', '22px', '22px', '22px', '22px', '22px', '28px'],
   lineHeight: ['30px', '32px'],
   marginBottom: ['16px', '24px'],
   fontWeight: '400',

--- a/src/components/table-of-contents/styles.ts
+++ b/src/components/table-of-contents/styles.ts
@@ -11,11 +11,19 @@ const item: (level: number, active: boolean) => SxStyleProp = (
   active
 ) => ({
   ml: '-1px',
-  pl: `${level * 8}px`,
-  py: ['6px', '6px', '6px', '6px', '4px'],
+  pl: [
+    `${level * 8}px`,
+    `${level * 8}px`,
+    `${level * 8}px`,
+    `${level * 8}px`,
+    `${level * 8}px`,
+    `${level * 8}px`,
+    `${(level + 1) * 8}px`,
+  ],
+  py: ['6px', '6px', '6px', '6px', '4px', '4px', '6px'],
   borderLeft: `1px solid ${active && level === 1 ? '#E31C58' : '#E7E9EE'}`,
-  fontSize: ['16px', '16px', '16px', '16px', '12px', '16px'],
-  lineHeight: ['22px', '22px', '22px', '22px', '16px', '18px'],
+  fontSize: ['16px', '16px', '16px', '16px', '12px', '16px', '24px'],
+  lineHeight: ['22px', '22px', '22px', '22px', '16px', '18px', '28px'],
   fontWeight: `${active ? '600' : '400'}`,
   color: `${active ? '#0C1522' : 'muted.0'}`,
 

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -12,7 +12,7 @@ import hljsCurl from 'highlightjs-curl'
 
 import remarkImages from 'utils/remark_plugins/plaiceholder'
 
-import { Box, Flex } from '@vtex/brand-ui'
+import { Box, Flex, Text } from '@vtex/brand-ui'
 
 import APIGuidesIcon from 'components/icons/api-guides-icon'
 import APIReferenceIcon from 'components/icons/api-reference-icon'
@@ -109,7 +109,9 @@ const DocumentationPage: NextPage<Props> = ({
             <Box sx={styles.contentContainer}>
               <article>
                 <Breadcrumb breadcumbList={breadcumbList} />
-                <h1>{serialized.frontmatter?.title}</h1>
+                <Text sx={styles.documentationTitle}>
+                  {serialized.frontmatter?.title}
+                </Text>
                 <MarkdownRenderer serialized={serialized} />
               </article>
             </Box>

--- a/src/styles/documentation-page.ts
+++ b/src/styles/documentation-page.ts
@@ -17,8 +17,13 @@ const articleBox: SxStyleProp = {
 }
 
 const contentContainer: SxStyleProp = {
-  width: ['auto', '544px', '544px', '544px', '544px', '720px'],
+  width: ['auto', '544px', '544px', '544px', '544px', '720px', '1080px'],
   mx: ['18px', 'initial'],
+}
+
+const documentationTitle: SxStyleProp = {
+  fontSize: ['32px', '32px', '32px', '32px', '32px', '32px', '48px'],
+  fontWeight: 'bold',
 }
 
 const bottomContributorsContainer: SxStyleProp = {
@@ -34,7 +39,7 @@ const bottomContributorsDivider: SxStyleProp = {
 }
 
 const rightContainer: SxStyleProp = {
-  ml: '64px',
+  ml: ['64px', '64px', '64px', '64px', '64px', '64px', '200px'],
   display: [
     'none !important',
     'none !important',
@@ -42,7 +47,7 @@ const rightContainer: SxStyleProp = {
     'none !important',
     'initial !important',
   ],
-  width: [0, 0, 0, 0, '189px', '284px'],
+  width: [0, 0, 0, 0, '189px', '284px', '402px'],
 }
 
 export default {
@@ -50,6 +55,7 @@ export default {
   mainContainer,
   articleBox,
   contentContainer,
+  documentationTitle,
   bottomContributorsContainer,
   bottomContributorsDivider,
   rightContainer,


### PR DESCRIPTION
#### What is the purpose of this pull request?

To adjust the content dimensions of API guide pages in last breakpoint (2560px).

#### What problem is this solving?

In the last breakpoint (2560px), the content is rendered too small, whick makes it difficult for users to read.

#### How should this be manually tested?

Go to [this page](https://deploy-preview-123--elated-hoover-5c29bf.netlify.app/docs/api-guides) and try accessing different documentation pages. Try testing different breakpoints and check if the page content is rendered in an adequate size.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
