### PR TITLE
Fix/see also frontmatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.1.0-vtex-12-gea2bc7e"
+      "version": "1.1.0-vtex-14-g021088c"
     }
   },
   "resolutions": {

--- a/src/components/documentation-card/styles.ts
+++ b/src/components/documentation-card/styles.ts
@@ -3,7 +3,7 @@ import { SxStyleProp } from '@vtex/brand-ui'
 const cardContainer: SxStyleProp = {
   my: ['16px', '16px', '16px', '16px', '16px', '16px', '24px'],
   padding: '8px',
-
+  cursor: 'pointer',
   ':active, :hover': {
     borderRadius: '4px',
     backgroundColor: '#F8F7FC',

--- a/src/components/search-input/results-box.tsx
+++ b/src/components/search-input/results-box.tsx
@@ -16,8 +16,16 @@ interface HitProps {
 
 const Hit = ({ hit, setSearchStateActive }: HitProps) => {
   const breadcrumbsList = getBreadcrumbs(hit)
-
+  const [title, setTitle] = useState<string>('')
   const DocIcon = getIcon(hit.doctype)
+
+  useEffect(() => {
+    if (hit.type === 'content') setTitle(hit.content)
+    else {
+      const hierarchy = JSON.parse(JSON.stringify(hit.hierarchy))
+      setTitle(hierarchy[hit.type])
+    }
+  }, [])
 
   return (
     <Link
@@ -29,7 +37,7 @@ const Hit = ({ hit, setSearchStateActive }: HitProps) => {
         <Flex>
           {DocIcon && <DocIcon className="hit-icon" sx={styles.hitIcon} />}
           <Text className="hit-content-title" sx={styles.hitContent}>
-            {hit.content}
+            {title}
           </Text>
         </Flex>
         <Flex sx={styles.alignCenter}>
@@ -72,7 +80,7 @@ const HitsBox = connectStateResults(({ searchState, searchResults }) => {
     <>
       {searchStateActive?.query && (
         <Box sx={styles.resultsContainer}>
-          <Box sx={styles.resultsBox}>
+          <Box sx={searchResults.hits.length && styles.resultsBox}>
             {searchResults.hits.map(
               (searchResult, index) =>
                 index < 7 && (
@@ -84,13 +92,18 @@ const HitsBox = connectStateResults(({ searchState, searchResults }) => {
                 )
             )}
           </Box>
-          {searchResults.hits.length > 7 && (
+          {false && searchResults.hits.length > 7 && (
             <Box
               sx={styles.seeAll}
               onClick={() => seeAllSubmit(searchStateActive.query!)}
             >
               <Text>See all results</Text>
             </Box>
+          )}
+          {!searchResults.hits.length && (
+            <Flex sx={styles.noResults}>
+              <Text>No results =(</Text>
+            </Flex>
           )}
         </Box>
       )}

--- a/src/components/search-input/styles.ts
+++ b/src/components/search-input/styles.ts
@@ -127,6 +127,12 @@ const searchContainer: SxStyleProp = {
   },
 }
 
+const noResults: SxStyleProp = {
+  justifyContent: 'center',
+  alignContent: 'center',
+  padding: '12px',
+}
+
 export default {
   resultsContainer,
   resultsBox,
@@ -141,4 +147,5 @@ export default {
   searchIcon,
   searchContainer,
   alignCenter,
+  noResults,
 }

--- a/src/components/see-also-section/functions.ts
+++ b/src/components/see-also-section/functions.ts
@@ -1,0 +1,40 @@
+import { capitalizeFirstLetter } from 'utils/string-utils'
+import { getIcon } from 'utils/constants'
+
+import { DocumentProps } from 'components/documentation-card'
+
+const getDoctype = (url: string) => {
+  const pathDoctype = url.split('/')[2]
+  switch (pathDoctype) {
+    case 'api-guides':
+      return 'API Guides'
+    case 'api-reference':
+      return 'API Reference'
+    case 'vtex-io':
+      return 'VTEX IO'
+    case 'fast-store':
+      return 'FastStore'
+    case 'store-framework-apps':
+      return 'Store Framework Apps'
+    default:
+      return 'API Guides'
+  }
+}
+
+const getTitleFromUrl = (url: string) => {
+  const path = url.split('/')
+  const words = path[path.length - 1].split('-')
+  return `${words.map(capitalizeFirstLetter).join(' ')}`
+}
+
+export const createDocFromUrl = (url: string): DocumentProps => {
+  const Icon = getIcon(getDoctype(url))!
+  const title = getTitleFromUrl(url)
+
+  return {
+    title,
+    Icon,
+    description: '',
+    link: url,
+  }
+}

--- a/src/components/see-also-section/index.tsx
+++ b/src/components/see-also-section/index.tsx
@@ -1,14 +1,18 @@
 import { Box, Text } from '@vtex/brand-ui'
 
 import DocumentationCard, { DocumentProps } from 'components/documentation-card'
+import { createDocFromUrl } from './functions'
 
 import styles from './styles'
-
 interface SeeAlsoSectionProps {
-  cards: DocumentProps[]
+  urls: string[]
 }
 
-const SeeAlsoSection = ({ cards }: SeeAlsoSectionProps) => {
+const SeeAlsoSection = ({ urls }: SeeAlsoSectionProps) => {
+  const cards: DocumentProps[] = []
+  urls?.forEach((url) => {
+    cards.push(createDocFromUrl(url))
+  })
   return (
     <Box sx={styles.seeAlsoContainer} data-cy="see-also-section">
       <Text sx={styles.sectionTitle}>See also</Text>

--- a/src/components/sidebar-elements/index.tsx
+++ b/src/components/sidebar-elements/index.tsx
@@ -6,7 +6,6 @@ import { SidebarContext } from 'utils/contexts/sidebar'
 import { MethodType } from 'utils/typings/unionTypes'
 
 import MethodCategory from 'components/method-category'
-import jp from 'jsonpath'
 
 import { styleByLevelNormal, textStyle } from './functions'
 import styles from './styles'
@@ -45,10 +44,42 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
     router.push(`/docs/${slugPrefix}${pathSuffix}`)
   }
 
-  const checkDocumentationType = (slug: string, type: string) => {
-    return (
-      jp.query(sidebarDataMaster, `$..*[?(@.slug=="${slug}")].type`)[0] == type
-    )
+  // eslint-disable-next-line
+  // @ts-ignore
+  const checkDocumentationType = (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    sidebarData: any,
+    slug: string,
+    type: string
+  ) => {
+    if (
+      !sidebarData ||
+      (typeof sidebarData !== 'object' && !Array.isArray(sidebarData))
+    ) {
+      return false
+    } else if (sidebarData?.slug == slug && sidebarData?.type == type) {
+      return true
+    } else if (Array.isArray(sidebarData)) {
+      for (let i = 0; i < sidebarData.length; i++) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const result = checkDocumentationType(sidebarData[i], slug, type)
+        if (result) {
+          return result
+        }
+      }
+    } else {
+      for (const k in sidebarData) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const result = checkDocumentationType(sidebarData[k], slug, type)
+        if (result) {
+          return result
+        }
+      }
+    }
+
+    return false
   }
 
   const ElementRoot = ({
@@ -88,7 +119,7 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
               onClick={() => toggleSidebarElementStatus(slug)}
             />
           )}
-          {!checkDocumentationType(slug, 'category') ? (
+          {!checkDocumentationType(sidebarDataMaster, slug, 'category') ? (
             <Link
               sx={textStyle(activeSidebarElement === slug, isExpandable)}
               onClick={(e: { preventDefault: () => void }) => {

--- a/src/components/sidebar-elements/index.tsx
+++ b/src/components/sidebar-elements/index.tsx
@@ -38,10 +38,11 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
 
   const handleClick = (
     e: { preventDefault: () => void },
-    pathSuffix: string
+    pathSuffix: string,
+    slug: string
   ) => {
     e.preventDefault()
-    router.push(`/docs/${slugPrefix}${pathSuffix}`)
+    router.push(getHref(slugPrefix || '', pathSuffix, slug))
   }
 
   // eslint-disable-next-line
@@ -80,6 +81,14 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
     }
 
     return false
+  }
+
+  const getHref = (slugPrefix: string, pathSuffix: string, slug: string) => {
+    const href =
+      slugPrefix === 'api-reference'
+        ? `/docs/${slugPrefix}/${slug}/${pathSuffix}`
+        : `/docs/${slugPrefix}/${slug}`
+    return href.replaceAll('//', '/')
   }
 
   const ElementRoot = ({
@@ -123,14 +132,10 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
             <Link
               sx={textStyle(activeSidebarElement === slug, isExpandable)}
               onClick={(e: { preventDefault: () => void }) => {
-                handleClick(e, pathSuffix)
+                handleClick(e, pathSuffix, slug)
                 toggleSidebarElementStatus(slug)
               }}
-              href={
-                'api-reference'
-                  ? `/docs/${slugPrefix}/${pathSuffix}`
-                  : `/docs/${slugPrefix}/${slug}`
-              }
+              href={getHref(slugPrefix || '', pathSuffix, slug)}
             >
               {method && (
                 <MethodCategory
@@ -167,14 +172,14 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
 
   const ElementChildren = ({ slug, children }: SidebarElement) => {
     const isExpandable = children.length > 0
-    const newPathPrefix =
-      slugPrefix === 'api-reference' ? `/api-reference/${slug}` : slugPrefix
+    // const newPathPrefix =
+    //   slugPrefix === 'api-reference' ? `/api-reference/${slug}` : slugPrefix
     return isExpandable &&
       sidebarElementStatus.has(slug) &&
       sidebarElementStatus.get(slug) ? (
       <Box>
         <SidebarElements
-          slugPrefix={newPathPrefix}
+          slugPrefix={slugPrefix}
           items={children}
           subItemLevel={subItemLevel + 1}
           key={`${slug}sd`}

--- a/src/pages/docs/api-guides/[slug].tsx
+++ b/src/pages/docs/api-guides/[slug].tsx
@@ -14,9 +14,6 @@ import remarkImages from 'utils/remark_plugins/plaiceholder'
 
 import { Box, Flex, Text } from '@vtex/brand-ui'
 
-import APIGuidesIcon from 'components/icons/api-guides-icon'
-import APIReferenceIcon from 'components/icons/api-reference-icon'
-
 import APIGuideContextProvider from 'utils/contexts/api-guide'
 
 import type { Item } from 'components/table-of-contents'
@@ -35,7 +32,6 @@ import getDocsPaths from 'utils/getDocsPaths'
 import replaceMagicBlocks from 'utils/replaceMagicBlocks'
 import escapeCurlyBraces from 'utils/escapeCurlyBraces'
 import replaceHTMLBlocks from 'utils/replaceHTMLBlocks'
-// import getDocsListPreval from 'utils/getDocsList.preval'
 
 import styles from 'styles/documentation-page'
 import getFileContributors, {
@@ -43,22 +39,6 @@ import getFileContributors, {
 } from 'utils/getFileContributors'
 
 const docsPathsGLOBAL = await getDocsPaths()
-
-const documentationCards = [
-  {
-    title: 'Billing Options',
-    description: 'API Guides',
-    link: '/docs/api-guides/billing-options',
-    Icon: APIGuidesIcon,
-  },
-  {
-    title:
-      'Catalog API - A long documentation title aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-    description: 'API Reference',
-    link: '/docs/api-reference/catalog',
-    Icon: APIReferenceIcon,
-  },
-]
 
 interface Props {
   content: string
@@ -75,7 +55,12 @@ const DocumentationPage: NextPage<Props> = ({
   contributors,
 }) => {
   const [headings, setHeadings] = useState<Item[]>([])
+  const [seeAlsoUrls, setSeeAlsoUrls] = useState()
   useEffect(() => {
+    if (serialized.frontmatter?.seeAlso)
+      setSeeAlsoUrls(
+        JSON.parse(JSON.stringify(serialized.frontmatter.seeAlso as string))
+      )
     setHeadings(headingList)
   }, [serialized.frontmatter])
 
@@ -122,7 +107,9 @@ const DocumentationPage: NextPage<Props> = ({
             </Box>
 
             <FeedbackSection />
-            <SeeAlsoSection cards={documentationCards} />
+            {serialized.frontmatter?.seeAlso && (
+              <SeeAlsoSection urls={seeAlsoUrls!} />
+            )}
           </Box>
           <Box sx={styles.rightContainer}>
             <Contributors contributors={contributors} />


### PR DESCRIPTION
#### What is the purpose of this pull request?

Render the "See also" section using the document front matter.

#### What problem is this solving?

Change the branch parameter to GitHub request to `readme-docs-dev` and go to this page and check if the URLs in the front matter of [this document](https://github.com/vtexdocs/dev-portal-content/blob/readme-docs-dev/docs/guides/Getting%20Started/checkout-overview.md?plain=1) are correctly rendered. Also, check other pages if the "See also" section is not displaying (the document hasn't "see also" URLs in the front matter).

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
