### PR TITLE
feat(sidebar-elements): support link type

### DIFF
--- a/src/components/sidebar-elements/index.tsx
+++ b/src/components/sidebar-elements/index.tsx
@@ -1,6 +1,13 @@
 import { useRouter } from 'next/router'
 import React, { Fragment, useContext } from 'react'
-import { Box, Flex, Link, Button, IconCaret } from '@vtex/brand-ui'
+import {
+  Box,
+  Flex,
+  Link,
+  Button,
+  IconCaret,
+  IconExternalLink,
+} from '@vtex/brand-ui'
 
 import { SidebarContext } from 'utils/contexts/sidebar'
 import { MethodType } from 'utils/typings/unionTypes'
@@ -150,6 +157,7 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
             </Link>
           ) : checkDocumentationType(sidebarDataMaster, slug, 'link') ? (
             <Link href={slug} target="_blank" sx={styles.elementText}>
+              <IconExternalLink size={16} sx={{ marginRight: '10px' }} />
               {name}
             </Link>
           ) : (

--- a/src/components/sidebar-elements/index.tsx
+++ b/src/components/sidebar-elements/index.tsx
@@ -128,7 +128,8 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
               onClick={() => toggleSidebarElementStatus(slug)}
             />
           )}
-          {!checkDocumentationType(sidebarDataMaster, slug, 'category') ? (
+          {!checkDocumentationType(sidebarDataMaster, slug, 'category') &&
+          !checkDocumentationType(sidebarDataMaster, slug, 'link') ? (
             <Link
               sx={textStyle(activeSidebarElement === slug, isExpandable)}
               onClick={(e: { preventDefault: () => void }) => {
@@ -145,6 +146,10 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
                   method={method}
                 />
               )}
+              {name}
+            </Link>
+          ) : checkDocumentationType(sidebarDataMaster, slug, 'link') ? (
+            <Link href={slug} target="_blank" sx={styles.elementText}>
               {name}
             </Link>
           ) : (


### PR DESCRIPTION
#### What is the purpose of this pull request?

Support `link` type from `navigation.json`

#### What problem is this solving?

Add link to faststore docs

#### How should this be manually tested?

Check the (Beta) FastStore link at `/docs/storefront-development`

#### Screenshots or example usage
![Screenshot 2022-12-30 at 14 54 19](https://user-images.githubusercontent.com/60782333/210099150-8cd5af7d-fab3-40ee-8509-69fcc3d26e5e.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
