### PR TITLE
Fix/Spacing in Last Breakpoint

### DIFF
--- a/src/components/markdown-renderer/index.tsx
+++ b/src/components/markdown-renderer/index.tsx
@@ -11,19 +11,7 @@ interface Props {
 }
 
 const MarkdownRenderer = ({ serialized }: Props) => (
-  <Box
-    sx={{
-      fontSize: [
-        'initial',
-        'initial',
-        'initial',
-        'initial',
-        'initial',
-        'initial',
-        '28px',
-      ],
-    }}
-  >
+  <Box>
     <Head>
       <link
         rel="stylesheet"

--- a/src/components/table-of-contents/styles.ts
+++ b/src/components/table-of-contents/styles.ts
@@ -22,8 +22,8 @@ const item: (level: number, active: boolean) => SxStyleProp = (
   ],
   py: ['6px', '6px', '6px', '6px', '4px', '4px', '6px'],
   borderLeft: `1px solid ${active && level === 1 ? '#E31C58' : '#E7E9EE'}`,
-  fontSize: ['16px', '16px', '16px', '16px', '12px', '16px', '24px'],
-  lineHeight: ['22px', '22px', '22px', '22px', '16px', '18px', '28px'],
+  fontSize: ['16px', '16px', '16px', '16px', '12px', '16px', '22px'],
+  lineHeight: ['22px', '22px', '22px', '22px', '16px', '18px', '24px'],
   fontWeight: `${active ? '600' : '400'}`,
   color: `${active ? '#0C1522' : 'muted.0'}`,
 

--- a/src/styles/documentation-page.ts
+++ b/src/styles/documentation-page.ts
@@ -18,7 +18,8 @@ const innerContainer: SxStyleProp = {
 
 const articleBox: SxStyleProp = {
   width: ['100%', 'initial'],
-  lineHeight: '22px',
+  fontSize: ['16px', '16px', '16px', '16px', '16px', '16px', '24px'],
+  lineHeight: 1.375,
   a: {
     color: '#E31C58',
   },
@@ -27,14 +28,14 @@ const articleBox: SxStyleProp = {
     marginBottom: '24px',
   },
   h1: {
-    fontSize: '32px',
+    fontSize: '2em',
     fontWeight: '400',
-    lineHeight: '40px',
+    lineHeight: 1.25,
   },
   h2: {
-    fontSize: '22px',
-    lineHeight: '32px',
-    paddingTop: '16px',
+    fontSize: '1.375em',
+    lineHeight: 1.45,
+    paddingTop: '0.73em',
     fontWeight: '400',
   },
   strong: {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix the font sizes and spacings in the last breakpoint.

#### What problem is this solving?

Some users reported that the font was too big and lines were overlapping in the last breakpoint. That is due to incorrect values for font size and line height in documentation pages.

#### How should this be manually tested?

Go to [this page](https://deploy-preview-142--elated-hoover-5c29bf.netlify.app/docs/guides) and try accessing some documentations. Try testing different breakpoints, specially the last one (2560px wide).

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
