### PR TITLE
build(package): update rapidoc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.1.0-vtex-14-g021088c"
+      "version": "1.1.0-vtex-17-g4c233e6"
     }
   },
   "resolutions": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Upgrade the rapidoc version. 

#### What problem is this solving?

Add the tooltip component to the breadcrumbs. Further information can be found [here](https://www.notion.so/vtexhandbook/Adicionar-tooltip-em-breadcrumbs-do-RapiDoc-bf9cb79de822451e82c57be5972d845c).

#### How should this be manually tested?

Open the [preview](https://deploy-preview-146--elated-hoover-5c29bf.netlify.app/), open different api reference pages and check if a tooltip appears in the breadcrumbs that contain ellipsis.
Review comments should be added to the corresponding [RapiDoc pull request](https://github.com/vtexdocs/RapiDoc/pull/14).

#### Screenshots or example usage

![Captura de tela de 2023-01-03 11-11-36](https://user-images.githubusercontent.com/62757720/210387203-b37f876f-f72d-43fd-b328-db2d4d6d9ad9.png)
![Captura de tela de 2023-01-03 11-12-14](https://user-images.githubusercontent.com/62757720/210387166-543cd940-f3ec-4b4d-ac40-a00a25305858.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
