### PR TITLE
build(package): update rapidoc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.1.2-vtex-5-gf62c85b"
+      "version": "1.1.2-vtex-8-ga89e77b"
     }
   },
   "resolutions": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Upgrade the rapidoc version. 

#### What problem is this solving?

When the sections Header Auth and Base URL are empty (without inputs) the section title and input margin still appear, making the page look as if there was an error and de inputs were not rendered correctly.

Further information can be found [here](https://www.notion.so/vtexhandbook/Campo-Header-Auth-e-Base-URL-sem-aparecer-os-inputs-c4ab13b29fa64cab94e8e711bdeada59).

#### How should this be manually tested?

Open the [preview](https://deploy-preview-148--elated-hoover-5c29bf.netlify.app/), then open the _Generate authentication token_ API reference page and check if the section Header Auth is hidden and the Base URL section doesn't have a empty space after the header. Then open other API reference pages and check if the sections are rendered as expected.

Review comments should be added to the corresponding [RapiDoc pull request](https://github.com/vtexdocs/RapiDoc/pull/15).

#### Screenshots or example usage

Before:
![Captura de tela de 2023-01-03 15-21-07](https://user-images.githubusercontent.com/62757720/210559245-dbe2d681-215b-4a4d-b9f6-a68479f0d34d.png)

After:
![Captura de tela de 2023-01-04 09-31-24](https://user-images.githubusercontent.com/62757720/210558236-952c6503-f0bf-4c8c-97ad-ab064ac16454.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
