### PR TITLE
Fix/Schema Tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.1.0-vtex-17-g4c233e6"
+      "version": "1.1.2-vtex-5-gf62c85b"
     }
   },
   "resolutions": {

--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -55,6 +55,7 @@ const APIPage: NextPage<Props> = ({ url }) => {
         render-style="focused"
         show-header="false"
         show-side-nav="false"
+        default-schema-tab="schema"
         fill-request-fields-with-example={true}
         theme="light"
         bg-color="#FFFFFF"


### PR DESCRIPTION
#### What is the purpose of this pull request?

To improve usability of API Reference pages by renaming the schema tab (the one that shows the parameters in an API request/response) and making it the default tab instead of the example one.

#### What problem is this solving?

Users are not being able to find the parameters for an API request/response easily.

#### How should this be manually tested?

Go to [this page](https://deploy-preview-151--elated-hoover-5c29bf.netlify.app/docs/api-reference/antifraud-provider-protocol#post-/transactions) and check that the schema tab (in the Request Body and Response sections) is now named "Parameters" and is active by default when you open the page (and the example tab is not). Try testing other documentations as well.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
