### PR TITLE
Fix/Missing Backtick

### DIFF
--- a/src/pages/docs/guides/[slug].tsx
+++ b/src/pages/docs/guides/[slug].tsx
@@ -180,7 +180,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     path
   )
 
-  let format = 'mdx'
+  let format: 'md' | 'mdx' = 'mdx'
   try {
     if (path.endsWith('.md')) {
       documentationContent = escapeCurlyBraces(documentationContent)


### PR DESCRIPTION
#### What is the purpose of this pull request?

To improve the log message when incorrectly formatted code blocks are found inside a markdown file and allow such pages to render despite the error.

#### What problem is this solving?

It is difficult for the tech writers to fix the incorrectly formatted code blocks inside markdown files with no information about where are the unmatched backticks. Also, a lot of pages are not being rendered because of that error.

#### How should this be manually tested?

Try acessing these pages and make sure they are being rendered (they don't 404):

- [asynchronous-integration](https://deploy-preview-153--elated-hoover-5c29bf.netlify.app/docs/guides/asynchronous-integration)
- [starting-to-work-on-master-data-with-json-schema](https://deploy-preview-153--elated-hoover-5c29bf.netlify.app/docs/guides/starting-to-work-on-master-data-with-json-schema)
- [subscriptions-api-v2-overview](https://deploy-preview-153--elated-hoover-5c29bf.netlify.app/docs/guides/subscriptions-api-v2-overview)
- [integrating-instore-to-a-new-payment-acquirer](https://deploy-preview-153--elated-hoover-5c29bf.netlify.app/docs/guides/integrating-instore-to-a-new-payment-acquirer)

Also check the deploy log and look for errors about incorrectly formatted code blocks. Make sure they specify the line and column of the first unmatched backtick.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
