### PR TITLE
Fixing table overflow in API Guide pages

### DIFF
--- a/src/components/markdown-renderer/components.tsx
+++ b/src/components/markdown-renderer/components.tsx
@@ -76,7 +76,9 @@ const Callout = ({ node, icon, ...props }: Component) => {
 
 export default {
   table: ({ node, ...props }: Component) => (
-    <table className={styles.table} {...props} />
+    <div className={styles.div}>
+      <table className={styles.table} {...props} />
+    </div>
   ),
   td: ({ node, ...props }: Component) => (
     <td className={styles.td} {...props} />

--- a/src/components/markdown-renderer/styles.module.css
+++ b/src/components/markdown-renderer/styles.module.css
@@ -1,7 +1,6 @@
 .table {
   border-collapse: collapse;
   border: 1px solid #e7e9ef;
-  margin: 25px 0;
   width: 100%;
 }
 
@@ -18,6 +17,12 @@
 
 .table tbody tr:nth-of-type(even) {
   background-color: #f8f7fc;
+}
+
+.div {
+  margin: 25px 0;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .img {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To limit table width by creating a div container and showing horizontal scrollbar if the table is too large.

#### What problem is this solving?

Tables that were too wide were extending beyond the limits of the page's content.

#### How should this be manually tested?

Try accessing, in the [preview](https://deploy-preview-161--elated-hoover-5c29bf.netlify.app/), pages that contain large tables and check if the width is limited as expected.
Try accessing these pages in different resolutions.

Example of pages that should be tested:
- [Add To Cart Button](https://deploy-preview-161--elated-hoover-5c29bf.netlify.app/docs/guides/vtex-add-to-cart-button)
- [Autocomplete](https://deploy-preview-161--elated-hoover-5c29bf.netlify.app/docs/guides/vtex-search-autocomplete)
- [Login SSO](https://deploy-preview-161--elated-hoover-5c29bf.netlify.app/docs/guides/login-integration-guide)

#### Screenshots or example usage
![Captura de tela de 2023-01-09 10-45-38](https://user-images.githubusercontent.com/62757720/211327844-6dcf152c-606a-4a81-b779-a9e039ff9e48.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
