### PR TITLE
build: update rapidoc version to have working api requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.1.5-vtex-4-gf1cc978"
+      "version": "1.1.6-vtex"
     }
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.1.5-vtex"
+      "version": "1.1.5-vtex-4-gf1cc978"
     }
   },
   "resolutions": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Update the RapiDoc version.

#### What problem is this solving?

Now is possible to send API requests in the API reference pages.

#### How should this be manually tested?

Open the [preview](https://deploy-preview-174--elated-hoover-5c29bf.netlify.app/) and try to do different api requests and check if the answer matches the expected one obtained by executing the curl code.

Review comments should be added to the [corresponding rapidoc PR](https://github.com/vtexdocs/RapiDoc/pull/20).

#### Screenshots or example usage

[Further information can be found here.](https://www.notion.so/vtexhandbook/Executar-request-nas-p-ginas-de-API-Reference-f49c0d1a7d9e401897c18367e2743c53)
![Captura de tela de 2023-01-10 15-07-32](https://user-images.githubusercontent.com/62757720/212075184-5e718153-3d1f-44dd-9959-ba65e6bfc7c1.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
