### PR TITLE
Fix/Responsive Design

### DIFF
--- a/src/components/breadcrumb/index.tsx
+++ b/src/components/breadcrumb/index.tsx
@@ -14,7 +14,7 @@ const Breadcrumb = ({ breadcumbList }: Props) => {
           <>
             <Text>{item.name}</Text>
             {idx < breadcumbList.length - 1 ? (
-              <IconCaret direction="right" sx={styles.caret} />
+              <IconCaret direction="right" size={16} />
             ) : (
               ''
             )}
@@ -25,7 +25,7 @@ const Breadcrumb = ({ breadcumbList }: Props) => {
               {item.name}
             </Link>
             {idx < breadcumbList.length - 1 ? (
-              <IconCaret direction="right" sx={styles.caret} />
+              <IconCaret direction="right" size={16} />
             ) : (
               ''
             )}

--- a/src/components/breadcrumb/styles.ts
+++ b/src/components/breadcrumb/styles.ts
@@ -15,9 +15,4 @@ const breadcrumbItem: SxStyleProp = {
   },
 }
 
-const caret: SxStyleProp = {
-  width: '16px',
-  height: '16px',
-}
-
-export default { breadcrumb, breadcrumbItem, caret }
+export default { breadcrumb, breadcrumbItem }

--- a/src/components/contributors/styles.ts
+++ b/src/components/contributors/styles.ts
@@ -12,8 +12,8 @@ const titleContainer: SxStyleProp = {
 
 const title: SxStyleProp = {
   fontWeight: '400',
-  fontSize: ['12px', '16px', '16px', '16px', '12px', '16px', '22px'],
-  lineHeight: ['16px', '22px', '22px', '22px', '16px', '18px', '22px'],
+  fontSize: ['12px', '16px', '16px', '16px', '12px', '16px'],
+  lineHeight: ['16px', '18px', '18px', '18px', '16px', '18px'],
   color: '#4A4A4A',
 }
 
@@ -24,68 +24,44 @@ const count: SxStyleProp = {
   height: '16px',
   borderRadius: '24px',
   backgroundColor: 'muted.4',
-  fontSize: ['12px', '12px', '12px', '12px', '12px', '12px', '22px'],
+  fontSize: '12px',
   fontWeight: '400',
   lineHeight: '16px',
   textAlign: 'center',
   color: '#4A4A4A',
 }
 
-const photosContainer: (rows: number) => SxStyleProp = (rows) => {
-  const maxHeight = (photoSize: number, gap: number) =>
-    `${photoSize * rows + gap * (rows - 1)}px`
-  const defaultMaxHeight = maxHeight(32, 8)
-
-  return {
-    mt: ['16px', '16px', '16px', '16px', '16px', '16px', '24px'],
-    gap: ['8px', '8px', '8px', '8px', '8px', '8px', '12px'],
-    gridTemplateColumns: [
-      '1fr 1fr 1fr 1fr',
-      '1fr 1fr 1fr 1fr 1fr 1fr',
-      '1fr 1fr 1fr 1fr 1fr 1fr',
-      '1fr 1fr 1fr 1fr 1fr 1fr',
-      '1fr 1fr 1fr 1fr',
-      '1fr 1fr 1fr 1fr 1fr',
-    ],
-    overflow: 'hidden',
-    width: [
-      0,
-      'min-content',
-      'min-content',
-      'min-content',
-      '152px',
-      '192px',
-      '288px',
-    ],
-    maxHeight: [
-      defaultMaxHeight,
-      defaultMaxHeight,
-      defaultMaxHeight,
-      defaultMaxHeight,
-      defaultMaxHeight,
-      defaultMaxHeight,
-      maxHeight(48, 12),
-    ],
-    transition: 'max-height 0.3s ease-in-out',
-  }
-}
+const photosContainer: (rows: number) => SxStyleProp = (rows) => ({
+  mt: '16px',
+  gap: '8px',
+  gridTemplateColumns: [
+    '1fr 1fr 1fr 1fr',
+    '1fr 1fr 1fr 1fr 1fr 1fr',
+    '1fr 1fr 1fr 1fr 1fr 1fr',
+    '1fr 1fr 1fr 1fr 1fr 1fr',
+    '1fr 1fr 1fr 1fr',
+    '1fr 1fr 1fr 1fr 1fr',
+  ],
+  overflow: 'hidden',
+  width: [0, 'min-content', 'min-content', 'min-content', '152px', '192px'],
+  maxHeight: `${32 * rows + 8 * (rows - 1)}px`,
+  transition: 'max-height 0.3s ease-in-out',
+})
 
 const photo: SxStyleProp = {
-  width: ['32px', '32px', '32px', '32px', '32px', '32px', '48px'],
-  height: ['32px', '32px', '32px', '32px', '32px', '32px', '48px'],
+  width: '32px',
+  height: '32px',
   img: {
-    width: ['32px', '32px', '32px', '32px', '32px', '32px', '48px'],
-    height: ['32px', '32px', '32px', '32px', '32px', '32px', '48px'],
+    width: '32px',
+    height: '32px',
     borderRadius: '100%',
   },
 }
 
 const collapseButton: SxStyleProp = {
-  mt: ['8px', '8px', '8px', '8px', '8px', '8px', '16px'],
+  ...title,
+  mt: '8px',
   height: '24px',
-  fontWeight: '400',
-  fontSize: ['12px', '12px', '12px', '12px', '12px', '12px', '22px'],
-  lineHeight: ['16px', '16px', '16px', '16px', '16px', '16px', '22px'],
   color: 'muted.0',
   cursor: 'pointer',
   alignItems: 'center',

--- a/src/components/documentation-card/functions.ts
+++ b/src/components/documentation-card/functions.ts
@@ -7,14 +7,14 @@ const cardContainer = (containerType: string) => {
       ? ['308px', '442px', '444px', '480px']
       : containerType === 'mobile'
       ? '100%'
-      : ['324px', '544px', '544px', '544px', '544px', '720px', '1080px']
+      : ['324px', '544px', '544px', '544px', '544px', '720px', '1400px']
 
   const textWidth =
     containerType === 'dropdown'
       ? ['276px', '410px', '412px', '432px']
       : containerType === 'mobile'
       ? '90%'
-      : ['276px', '496px', '496px', '496px', '496px', '672px', '1032px']
+      : ['276px', '496px', '496px', '496px', '496px', '672px', '1352px']
 
   const cardContainer: SxStyleProp = {
     ...styles.cardContainer,
@@ -30,9 +30,7 @@ const cardContainer = (containerType: string) => {
 
 const titleContainer = (containerType: string) => {
   const marginBottom =
-    containerType === 'dropdown'
-      ? ['5px', '5px', '5px', '1px']
-      : ['8px', '8px', '8px', '8px', '8px', '8px', '12px']
+    containerType === 'dropdown' ? ['5px', '5px', '5px', '1px'] : '8px'
 
   const titleContainer: SxStyleProp = {
     ...styles.titleContainer,
@@ -49,8 +47,13 @@ const cardTitle = (containerType: string) => {
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
           overflow: 'hidden',
+          fontSize: '18px',
+          lineHeight: '24px',
         }
-      : {}
+      : {
+          fontSize: '16px',
+          lineHeight: '22px',
+        }
 
   const cardTitle: SxStyleProp = {
     ...styles.title,

--- a/src/components/documentation-card/index.tsx
+++ b/src/components/documentation-card/index.tsx
@@ -22,7 +22,7 @@ const DocumentationCard = ({
     <Link href={link} legacyBehavior>
       <Box sx={cardContainer(containerType)}>
         <Flex sx={titleContainer(containerType)}>
-          <Icon sx={styles.icon} />
+          <Icon size={24} />
           <Text className="title" sx={cardTitle(containerType)}>
             {title}
           </Text>

--- a/src/components/documentation-card/styles.ts
+++ b/src/components/documentation-card/styles.ts
@@ -26,34 +26,21 @@ const titleContainer: SxStyleProp = {
   alignItems: 'center',
 }
 
-const icon: SxStyleProp = {
-  width: ['24px', '24px', '24px', '24px', '24px', '24px', '36px'],
-  height: ['24px', '24px', '24px', '24px', '24px', '24px', '36px'],
-}
-
-const text: SxStyleProp = {
-  fontSize: ['16px', '16px', '16px', '16px', '16px', '16px', '24px'],
-  lineHeight: ['22px', '22px', '22px', '22px', '22px', '22px', '28px'],
-  fontWeight: '400',
-  textTransform: 'none',
-}
-
 const title: SxStyleProp = {
-  ...text,
-  ml: ['8px', '8px', '8px', '8px', '8px', '8px', '12px'],
+  ml: '8px',
   color: 'muted.0',
 }
 
 const description: SxStyleProp = {
-  ...text,
-  ml: ['32px', '32px', '32px', '32px', '32px', '32px', '48px'],
+  ml: '32px',
+  fontSize: '16px',
+  lineHeight: '18px',
   color: 'muted.1',
 }
 
 export default {
   cardContainer,
   description,
-  icon,
   title,
   titleContainer,
 }

--- a/src/components/feedback-section/index.tsx
+++ b/src/components/feedback-section/index.tsx
@@ -47,9 +47,9 @@ const FeedbackSection = ({ docPath, suggestEdits = true }: DocPath) => {
           onClick={feedback === undefined ? () => openModal(true) : null}
         >
           {feedback === undefined || !feedback ? (
-            <LikeIcon sx={styles.likeIcon} />
+            <LikeIcon size={24} sx={styles.likeIcon} />
           ) : (
-            <LikeSelectedIcon sx={styles.likeIcon} />
+            <LikeSelectedIcon size={24} sx={styles.likeIcon} />
           )}
           <Text>{messages['feedback_section.positive']}</Text>
         </Flex>
@@ -59,9 +59,9 @@ const FeedbackSection = ({ docPath, suggestEdits = true }: DocPath) => {
           onClick={feedback === undefined ? () => openModal(false) : null}
         >
           {feedback === undefined || feedback ? (
-            <LikeIcon sx={styles.dislikeIcon} />
+            <LikeIcon size={24} sx={styles.dislikeIcon} />
           ) : (
-            <LikeSelectedIcon sx={styles.dislikeIcon} />
+            <LikeSelectedIcon size={24} sx={styles.dislikeIcon} />
           )}
           <Text>{messages['feedback_section.negative']}</Text>
         </Flex>
@@ -73,7 +73,7 @@ const FeedbackSection = ({ docPath, suggestEdits = true }: DocPath) => {
           href={urlToEdit}
           sx={styles.editContainer}
         >
-          <EditIcon sx={styles.editIcon} />
+          <EditIcon size={24} sx={styles.editIcon} />
           <Text>{messages['feedback_section.edit']}</Text>
         </Link>
       )}

--- a/src/components/feedback-section/styles.ts
+++ b/src/components/feedback-section/styles.ts
@@ -11,8 +11,8 @@ const container: SxStyleProp = {
 }
 
 const question: SxStyleProp = {
-  fontSize: ['16px', '16px', '16px', '16px', '16px', '16px', '22px'],
-  lineHeight: '22px',
+  fontSize: '16px',
+  lineHeight: '18px',
 }
 
 const likeContainer: SxStyleProp = {
@@ -24,18 +24,11 @@ const likeContainer: SxStyleProp = {
   justifyContent: ['center', 'initial'],
 }
 
-const icon: SxStyleProp = {
-  width: ['24px', '24px', '24px', '24px', '24px', '24px', '32px'],
-  height: ['24px', '24px', '24px', '24px', '24px', '24px', '32px'],
-}
-
 const likeIcon: SxStyleProp = {
-  ...icon,
   mr: '2px',
 }
 
 const dislikeIcon: SxStyleProp = {
-  ...icon,
   mr: '2px',
   transform: 'rotateX(180deg) rotateY(180deg)',
 }
@@ -65,7 +58,7 @@ const selectedButton: SxStyleProp = {
 const box: SxStyleProp = {
   alignItems: 'center',
   color: 'muted.0',
-  fontSize: ['16px', '16px', '16px', '16px', '16px', '16px', '22px'],
+  fontSize: '16px',
   lineHeight: '22px',
 }
 
@@ -76,7 +69,7 @@ const editContainer: SxStyleProp = {
   display: 'flex',
 }
 
-const editIcon: SxStyleProp = { ...icon, mr: '4px' }
+const editIcon: SxStyleProp = { mr: '4px' }
 
 export default {
   container,

--- a/src/components/header/styles.ts
+++ b/src/components/header/styles.ts
@@ -46,6 +46,7 @@ const rightLinksItem: SxStyleProp = {
 }
 
 const dropdownContainer: SxStyleProp = {
+  textTransform: 'none',
   justifyContent: 'flex-end',
   height: 'calc(100% + 1px)',
   cursor: 'pointer',

--- a/src/components/page-header/styles.ts
+++ b/src/components/page-header/styles.ts
@@ -5,12 +5,11 @@ const welcomeHeader: SxStyleProp = {
   position: ['initial', 'absolute'],
   mb: ['32px', 'initial'],
   zIndex: '1000',
-  maxWidth: ['380px', 'initial'],
-  width: ['380px', '380px', '380px', '380px', '380px', '380px'],
+  width: ['320px', '345px', '345px', '345px', '345px', '720px'],
 }
 
 const welcomeSubtitle: SxStyleProp = {
-  textAlign: ['left', 'initial'],
+  textAlign: ['center', 'initial'],
   fontSize: ['16px', '18px'],
   fontWeight: '400',
   color: '#A1A8B3',
@@ -26,11 +25,12 @@ const welcomeInnerContainer: SxStyleProp = {
   position: ['initial', 'relative'],
   left: [
     'initial',
-    'calc(50% - 1194px / 2 + 325px)',
-    'calc(50% - 1194px / 2 + 325px)',
-    'calc(50% - 1194px / 2 + 325px)',
-    'calc(50% - 1280px / 2 + 280px)',
-    'calc(50% - 1213px / 2 + 247px)',
+    'calc(50% - 544px / 2)',
+    'calc(50% - 544px / 2)',
+    'calc(50% - 544px / 2)',
+    'calc(50% - 720px / 2)',
+    'calc(50% - 720px / 2)',
+    'calc(50% - 1400px / 2)',
   ],
   justifyContent: 'space-between',
   alignItems: ['center', 'initial'],
@@ -38,8 +38,8 @@ const welcomeInnerContainer: SxStyleProp = {
 
 const welcomeText: SxStyleProp = {
   boxSizing: 'initial',
-  textAlign: ['left', 'initial'],
-  fontSize: ['22px', '32px'],
+  textAlign: ['center', 'initial'],
+  fontSize: ['22px', '28px'],
   fontWeight: '400',
   lineHeight: ['30px', '38px'],
   paddingBottom: '8px',

--- a/src/components/release-note/styles.ts
+++ b/src/components/release-note/styles.ts
@@ -2,10 +2,12 @@ import { SxStyleProp } from '@vtex/brand-ui'
 
 const releaseContainer: SxStyleProp = {
   mb: ['32px', '48px'],
+  width: '100%',
 }
 
 const actionType: SxStyleProp = {
   fontSize: '16px',
+  lineHeight: ['22px', '18px'],
   ml: '-16px',
 }
 
@@ -18,8 +20,6 @@ const actionIcon: SxStyleProp = {
 
 const content: SxStyleProp = {
   flexDirection: 'column',
-  maxWidth: ['272px', '495px', '495px', '495px', '671px'],
-  minWidth: ['272px', '495px', '495px', '495px', '671px'],
   pt: 0,
   ml: '-16px',
   mt: '-32px',
@@ -29,15 +29,15 @@ const content: SxStyleProp = {
 const releaseDate: SxStyleProp = {
   color: 'muted.1',
   fontSize: ['12px', '16px'],
-  lineHeight: '22px',
+  lineHeight: ['16px', '22px'],
 }
 
 const releaseTitle: SxStyleProp = {
   color: '#4A596B',
   fontSize: ['16px', '18px'],
   lineHeight: ['22px', '24px'],
-  pt: '8px',
   cursor: 'pointer',
+  mt: '16px',
 }
 
 const releaseTitleActive: SxStyleProp = {
@@ -47,9 +47,10 @@ const releaseTitleActive: SxStyleProp = {
 
 const releaseDescription: SxStyleProp = {
   color: '#4A4A4A',
-  fontSize: ['12px', '16px'],
+  fontSize: ['12px', '16px', '16px', '16px', '16px', '16px', '18px'],
   lineHeight: ['16px', '22px'],
   mt: '8px',
+  mb: '-16px',
 }
 
 const arrowIcon: SxStyleProp = {

--- a/src/components/release-section/index.tsx
+++ b/src/components/release-section/index.tsx
@@ -15,8 +15,8 @@ interface IReleasesData {
 const ReleaseSection = ({ releasesData }: IReleasesData) => {
   const releases = releasesData.filter((release) => !release.hidden)
   return (
-    <Flex sx={styles.container}>
-      <Box>
+    <Flex sx={styles.outerContainer}>
+      <Box sx={styles.innerContainer}>
         <Text sx={styles.sectionTitle}>
           {messages['release_notes_page.title']}
         </Text>

--- a/src/components/release-section/styles.tsx
+++ b/src/components/release-section/styles.tsx
@@ -1,15 +1,18 @@
 import { SxStyleProp } from '@vtex/brand-ui'
 
-const container: SxStyleProp = {
-  justifyContent: 'center',
-  width: '100%',
-  mx: ['18px', '24px', 0],
+const outerContainer: SxStyleProp = {
+  mx: 'auto',
   mb: '64px',
+  width: ['324px', '544px', '544px', '544px', '720px', '720px', '1400px'],
+}
+
+const innerContainer: SxStyleProp = {
+  width: '100%',
 }
 
 const sectionTitle: SxStyleProp = {
-  fontSize: '28px',
-  lineHeight: '38px',
+  fontSize: ['20px', '28px'],
+  lineHeight: ['30px', '38px'],
   color: '#4A4A4A',
   pt: '64px',
   mb: '8px',
@@ -17,8 +20,8 @@ const sectionTitle: SxStyleProp = {
 
 const sectionSubtitle: SxStyleProp = {
   color: '#A1A8B3',
-  fontSize: '16px',
-  lineHeight: '18px',
+  fontSize: ['12px', '16px'],
+  lineHeight: ['16px', '18px'],
   mb: '24px',
 }
 
@@ -32,17 +35,19 @@ const sectionDivider: SxStyleProp = {
 
 const releaseDate: SxStyleProp = {
   fontSize: ['14px', '18px'],
+  lineHeight: ['20px', '24px'],
   mb: ['16px', '24px'],
 }
 
 const releaseCreationDay: SxStyleProp = {
   color: 'muted.1',
   fontSize: ['12px', '16px'],
-  lineHeight: '22px',
+  lineHeight: ['16px', '22px'],
 }
 
 export default {
-  container,
+  outerContainer,
+  innerContainer,
   sectionTitle,
   sectionSubtitle,
   sectionDivider,

--- a/src/components/search-results/styles.ts
+++ b/src/components/search-results/styles.ts
@@ -1,7 +1,7 @@
 import { SxStyleProp } from '@vtex/brand-ui'
 
 const resultContainer: SxStyleProp = {
-  width: '720px',
+  width: ['324px', '544px', '544px', '544px', '720px', '720px', '1400px'],
   paddingTop: '64px',
   hr: {
     marginTop: '16px',

--- a/src/components/search-sections/styles.ts
+++ b/src/components/search-sections/styles.ts
@@ -5,7 +5,7 @@ const container: SxStyleProp = {
   width: '242px',
   border: '1px solid #E7E9EE',
   borderRadius: '4px',
-  mr: '32px',
+  mr: ['32px', '32px', '32px', '32px', '32px', '32px', '64px'],
   mt: '96px',
 }
 

--- a/src/components/see-also-section/styles.ts
+++ b/src/components/see-also-section/styles.ts
@@ -1,12 +1,12 @@
 import { SxStyleProp } from '@vtex/brand-ui'
 
 const seeAlsoContainer: SxStyleProp = {
-  maxWidth: ['324px', '544px', '544px', '544px', '544px', '720px', '1080px'],
+  maxWidth: ['324px', '544px', '544px', '544px', '544px', '720px', '1400px'],
   mx: ['18px', 'initial'],
 }
 
 const sectionTitle: SxStyleProp = {
-  fontSize: ['18px', '22px', '22px', '22px', '22px', '22px', '28px'],
+  fontSize: ['18px', '22px'],
   lineHeight: ['30px', '32px'],
   marginBottom: ['16px', '24px'],
   fontWeight: '400',

--- a/src/components/table-of-contents/index.tsx
+++ b/src/components/table-of-contents/index.tsx
@@ -41,7 +41,6 @@ const TableOfContents = () => {
             subItem: level === 1 ? '' : slug,
           }))
         }}
-        legacyBehavior
       >
         <Text sx={styles.item(level, active)}>{title}</Text>
       </Link>

--- a/src/components/table-of-contents/styles.ts
+++ b/src/components/table-of-contents/styles.ts
@@ -9,28 +9,30 @@ const itemsContainer: SxStyleProp = {
 const item: (level: number, active: boolean) => SxStyleProp = (
   level,
   active
-) => ({
-  ml: '-1px',
-  pl: [
-    `${level * 8}px`,
-    `${level * 8}px`,
-    `${level * 8}px`,
-    `${level * 8}px`,
-    `${level * 8}px`,
-    `${level * 8}px`,
-    `${(level + 1) * 8}px`,
-  ],
-  py: ['6px', '6px', '6px', '6px', '4px', '4px', '6px'],
-  borderLeft: `1px solid ${active && level === 1 ? '#E31C58' : '#E7E9EE'}`,
-  fontSize: ['16px', '16px', '16px', '16px', '12px', '16px', '22px'],
-  lineHeight: ['22px', '22px', '22px', '22px', '16px', '18px', '24px'],
-  fontWeight: `${active ? '600' : '400'}`,
-  color: `${active ? '#0C1522' : 'muted.0'}`,
+) => {
+  const defaultLineHeight = `${level === 1 ? 18 : 22}px`
+  return {
+    ml: '-1px',
+    pl: `${level * 8}px`,
+    py: ['6px', '6px', '6px', '6px', '4px', '4px'],
+    borderLeft: `1px solid ${active && level === 1 ? '#E31C58' : '#E7E9EE'}`,
+    fontSize: ['16px', '16px', '16px', '16px', '12px', '16px'],
+    lineHeight: [
+      defaultLineHeight,
+      defaultLineHeight,
+      defaultLineHeight,
+      defaultLineHeight,
+      `${level === 1 ? 16 : 18}px`,
+      defaultLineHeight,
+    ],
+    fontWeight: `${active ? '600' : '400'}`,
+    color: `${active ? '#0C1522' : 'muted.0'}`,
 
-  ':hover': {
-    color: '#000711',
-  },
-})
+    ':hover': {
+      color: '#000711',
+    },
+  }
+}
 
 const subItemsContainer: SxStyleProp = {
   ml: '16px',

--- a/src/components/whats-next-card/styles.ts
+++ b/src/components/whats-next-card/styles.ts
@@ -5,7 +5,7 @@ const container: SxStyleProp = {
   padding: '16px',
   borderRadius: '4px',
   border: '1px solid #E7E9EE',
-  width: 'calc(50% - 8px)',
+  width: ['324px', '264px', '264px', '264px', '352px', '352px', '694px'],
   transition: 'all 0.3s ease-out',
   ':hover': {
     cursor: 'pointer',
@@ -36,9 +36,9 @@ const title: SxStyleProp = {
 }
 
 const description: SxStyleProp = {
-  fontSize: '14px',
+  fontSize: '12px',
   fontWeight: '400',
-  lineHeight: '18px',
+  lineHeight: '16px',
   color: 'muted.0',
 }
 

--- a/src/pages/updates/release-notes/index.tsx
+++ b/src/pages/updates/release-notes/index.tsx
@@ -4,7 +4,7 @@ import { DocumentationTitle, UpdatesTitle } from 'utils/typings/unionTypes'
 import getNavigation from 'utils/getNavigation'
 import ReleaseSection from '../../../components/release-section'
 
-import styles from 'styles/api-guides'
+import styles from 'styles/release-notes'
 import getReleasesData from 'utils/getReleasesData'
 import { UpdateElement } from 'utils/typings/types'
 import Head from 'next/head'

--- a/src/styles/documentation-landing-page.ts
+++ b/src/styles/documentation-landing-page.ts
@@ -16,7 +16,7 @@ const contentContainer: SxStyleProp = {
   mb: ['32px', '64px'],
   px: ['18px', 'initial'],
   maxWidth: ['324px', 'initial'],
-  width: ['auto', '544px', '544px', '544px', '720px'],
+  width: ['auto', '544px', '544px', '544px', '720px', '720px', '1400px'],
   boxSizing: 'initial',
   color: '#4A4A4A',
   lineHeight: ['22px', '24px'],

--- a/src/styles/documentation-page.ts
+++ b/src/styles/documentation-page.ts
@@ -55,18 +55,18 @@ const contentContainer: SxStyleProp = {
 }
 
 const documentationTitle: SxStyleProp = {
-  fontSize: '28px',
-  fontWeight: '400',
-  lineHeight: '38px',
   marginTop: '16px',
+  fontSize: ['20px', '28px'],
+  lineHeight: ['30px', '38px'],
+  fontWeight: '400',
 }
 
 const documentationExcerpt: SxStyleProp = {
   color: '#A1A8B3',
-  fontSize: '16px',
-  fontWeight: '400',
-  lineHeight: '18px',
   padding: '8px 0 24px',
+  fontSize: ['12px', '16px'],
+  lineHeight: ['16px', '18px'],
+  fontWeight: '400',
 }
 
 const bottomContributorsContainer: SxStyleProp = {
@@ -97,6 +97,7 @@ const releaseAction: SxStyleProp = {
   display: 'flex',
   gap: '10px',
   fontSize: '18px',
+  mb: '8px',
 }
 
 const divider: SxStyleProp = {

--- a/src/styles/documentation-page.ts
+++ b/src/styles/documentation-page.ts
@@ -18,7 +18,8 @@ const innerContainer: SxStyleProp = {
 
 const articleBox: SxStyleProp = {
   width: ['100%', 'initial'],
-  lineHeight: 1.375,
+  fontSize: '18px',
+  lineHeight: '24px',
   a: {
     color: '#E31C58',
   },
@@ -26,23 +27,45 @@ const articleBox: SxStyleProp = {
     borderBottom: '1px solid #E7E9EE',
     marginBottom: '24px',
   },
+  h1: {
+    fontSize: '2em',
+    fontWeight: '400',
+    lineHeight: 1.25,
+  },
+  h2: {
+    fontSize: '22px',
+    lineHeight: '32px',
+    fontWeight: '400',
+    pt: '8px',
+    my: '16px',
+  },
+  h3: {
+    fontSize: '18px',
+    fontWeight: '600',
+    lineHeight: '24px',
+  },
+  strong: {
+    fontWeight: '600',
+  },
 }
 
 const contentContainer: SxStyleProp = {
-  width: ['auto', '544px', '544px', '544px', '544px', '720px', '1080px'],
+  width: ['auto', '544px', '544px', '544px', '544px', '720px', '1400px'],
   mx: ['18px', 'initial'],
 }
 
 const documentationTitle: SxStyleProp = {
+  fontSize: '28px',
+  fontWeight: '400',
+  lineHeight: '38px',
   marginTop: '16px',
-  fontSize: '32px',
-  lineHeight: ['38px', '38px', '38px', '38px', '38px', '38px', '54px'],
 }
 
 const documentationExcerpt: SxStyleProp = {
   color: '#A1A8B3',
-  fontSize: '18px',
+  fontSize: '16px',
   fontWeight: '400',
+  lineHeight: '18px',
   padding: '8px 0 24px',
 }
 
@@ -67,7 +90,7 @@ const rightContainer: SxStyleProp = {
     'none !important',
     'initial !important',
   ],
-  width: [0, 0, 0, 0, '189px', '284px', '402px'],
+  width: [0, 0, 0, 0, '189px', '284px'],
 }
 
 const releaseAction: SxStyleProp = {

--- a/src/styles/release-notes.ts
+++ b/src/styles/release-notes.ts
@@ -1,7 +1,6 @@
 import { SxStyleProp } from '@vtex/brand-ui'
 
 const container: SxStyleProp = {
-  pt: '5rem',
   background: '#FFFFFF',
 }
 

--- a/src/styles/search-page.ts
+++ b/src/styles/search-page.ts
@@ -1,8 +1,8 @@
 import { SxStyleProp } from '@vtex/brand-ui'
 
 const body: SxStyleProp = {
-  paddingTop: '5rem',
   background: '#FFFFFF',
+  justifyContent: 'center',
 }
 
 export default {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix the layout of some of the portal's pages in some breakpoints.

#### What problem is this solving?

Some of the portal's pages don't have the correct layout and sizes for some breakpoints (specially the 2560px wide one), according to the designs at https://www.figma.com/file/Lx6sXdrw9KEvtSEKWttmv8/Developer-Portal?node-id=6005%3A350485&t=D9AYHlD9w90KluBr-0 and https://www.figma.com/file/QeNbcHLkqTAury0bNhkpzS/Developers-portal---Screens-2560px?node-id=0%3A1&t=3L9Ph99lex92pj7C-0.

#### How should this be manually tested?

Go to [this website](https://deploy-preview-180--elated-hoover-5c29bf.netlify.app/) and try accessing different pages with different window sizes. Look for differences between the expected layout and the actual one. Keep in mind some pages are not 100% responsive yet. The following fixes are yet to be implemented:

- Add pagination to the first three breakpoints of the search results page
- Remove the filter section component and add filter tabs to the first three brekpoints of the search results page
- Fix the layout of the API Reference pages

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
