### PR TITLE
fix(blockquote): use trimStart instead of trim

### DIFF
--- a/src/pages/docs/guides/rehypeBlockquote.js
+++ b/src/pages/docs/guides/rehypeBlockquote.js
@@ -54,8 +54,8 @@ const formatValues = (value, regEx) => {
       .split('\n')
       .map((val) => {
         if (val.length === 2) return val.concat(' ').replace(regEx, '')
-        return val.replace(regEx, '').trim()
+        return val.replace(regEx, '').trimStart()
       })
       .join('\n')
-  } else return value.replace(regEx, '').trim()
+  } else return value.replace(regEx, '').trimStart()
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Show whitespace between text and link inside a callout.

#### What problem is this solving?

Fixing problem reported in user feedback.

#### How should this be manually tested?

Open the [preview](https://deploy-preview-181--elated-hoover-5c29bf.netlify.app/docs/guides/profile-system) and check if in the callouts the links are rendered with a space separating them from the rest of the text.

_Other problems can be noted in some callouts: a leading character that does not render correctly and looks like the text has a extra whitespace, the string contains \n instead of breaking a new line. These problems will be fixed in other tasks._

#### Screenshots or example usage

Before:
![Captura de tela de 2023-01-16 10-50-59](https://user-images.githubusercontent.com/62757720/212693682-8c43b6e0-b771-4496-88cb-dd8d50e1fee5.png)

After:
![Captura de tela de 2023-01-16 10-51-37](https://user-images.githubusercontent.com/62757720/212693814-65e9aa2b-3a13-499c-bf7b-c2ef52a2fb17.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
