### PR TITLE
fix: add list migration doc to navigation.json

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -11707,6 +11707,13 @@
               "children": []
             },
             {
+              "name": "List Migration",
+              "slug": "vtex-list-listmigration",
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
               "name": "List Modal",
               "slug": "vtex-list-listmodal",
               "origin": "",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adding a missing page (gift list migration documentation) to navigation.json. Relates to https://github.com/vtexdocs/dev-portal-content/pull/145.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
