### PR TITLE
feat(search-input): custom highlighting to search results

### DIFF
--- a/src/components/search-input/customHighlight.tsx
+++ b/src/components/search-input/customHighlight.tsx
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useEffect, useState } from 'react'
+import { connectHighlight } from 'react-instantsearch-dom'
+import { Flex, Text } from '@vtex/brand-ui'
+import styles from './styles'
+
+const Highlight = ({ highlight, attribute, hit }: any) => {
+  const [parsedHit, setParsedHit] = useState([])
+
+  useEffect(() => {
+    const titleSize = 40
+    const highlightParts: any = []
+    let highlightCount = 0,
+      highlightLength = 0
+
+    const hitHighlights = highlight({
+      highlightProperty: '_highlightResult',
+      attribute: hit.type != 'content' ? `hierarchy.${hit.type}` : attribute,
+      hit,
+    })
+
+    hitHighlights.forEach((match: any, index: number) => {
+      const isBetween =
+        index > 0 && index < hitHighlights.length - 1 ? true : false
+      if (match.isHighlighted) {
+        if (isBetween) highlightCount++
+        highlightCount++
+        highlightLength += match.value.length
+      } else {
+        highlightParts.push({
+          index,
+          isBetween,
+          size: match.value.length,
+        })
+      }
+    })
+
+    highlightParts.sort((a: any, b: any) => a.size - b.size)
+    let sizeRemaining = titleSize - highlightLength
+    let size = sizeRemaining / highlightCount
+    highlightParts.forEach((match: any) => {
+      const value = hitHighlights[match.index].value
+      if (match.isBetween) {
+        if (match.size >= size * 2) {
+          const reticences = (size * 2 - 3) / 2
+          hitHighlights[match.index].value =
+            value.slice(0, reticences) +
+            '...' +
+            value.slice(value.length - reticences)
+          sizeRemaining -= size * 2
+        } else {
+          sizeRemaining -= match.size
+        }
+        highlightCount -= 2
+      } else {
+        if (match.size >= size) {
+          if (match.index === 0)
+            hitHighlights[match.index].value =
+              '...' + value.slice(value.length - (size - 3))
+          else
+            hitHighlights[match.index].value = value.slice(0, size - 3) + '...'
+          sizeRemaining -= size
+        } else {
+          sizeRemaining -= match.size
+        }
+        highlightCount -= 1
+      }
+      size = sizeRemaining / highlightCount
+      hitHighlights[match.index]
+    })
+    setParsedHit(hitHighlights)
+  }, [hit])
+
+  return (
+    <Flex className="hit-content-title">
+      {parsedHit.map((part: any, index: any) =>
+        part.isHighlighted ? (
+          <Text sx={styles.hitContentHighlighted} key={index}>
+            {part.value}
+          </Text>
+        ) : (
+          <Text sx={styles.hitContent} key={index}>
+            {part.value}
+          </Text>
+        )
+      )}
+    </Flex>
+  )
+}
+
+export default connectHighlight(Highlight)

--- a/src/components/search-input/customHighlight.tsx
+++ b/src/components/search-input/customHighlight.tsx
@@ -1,14 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { connectHighlight } from 'react-instantsearch-dom'
 import { Flex, Text } from '@vtex/brand-ui'
 import styles from './styles'
 
 const Highlight = ({ highlight, attribute, hit }: any) => {
   const [parsedHit, setParsedHit] = useState([])
+  const textContainer = useRef<HTMLElement>(null)
 
   useEffect(() => {
-    const titleSize = 40
+    const titleSize = textContainer.current
+      ? textContainer.current.offsetWidth / 7.75
+      : 40
     const highlightParts: any = []
     let highlightCount = 0,
       highlightLength = 0
@@ -66,13 +69,19 @@ const Highlight = ({ highlight, attribute, hit }: any) => {
         highlightCount -= 1
       }
       size = sizeRemaining / highlightCount
-      hitHighlights[match.index]
+      hitHighlights[match.index].value = hitHighlights[
+        match.index
+      ].value.replace(/\s+/g, '\u00A0')
     })
     setParsedHit(hitHighlights)
-  }, [hit])
+  }, [hit, textContainer.current])
 
   return (
-    <Flex className="hit-content-title">
+    <Flex
+      ref={textContainer}
+      className="hit-content-title"
+      sx={styles.hitContentContainer}
+    >
       {parsedHit.map((part: any, index: any) =>
         part.isHighlighted ? (
           <Text sx={styles.hitContentHighlighted} key={index}>

--- a/src/components/search-input/results-box.tsx
+++ b/src/components/search-input/results-box.tsx
@@ -7,6 +7,7 @@ import { Box, Flex, IconCaret, Text } from '@vtex/brand-ui'
 
 import { getIcon, messages } from 'utils/constants'
 import { getBreadcrumbs, getRelativeURL } from './functions'
+import CustomHighlight from './customHighlight'
 import styles from './styles'
 
 interface HitProps {
@@ -16,26 +17,14 @@ interface HitProps {
 
 const Hit = ({ hit, setSearchStateActive }: HitProps) => {
   const breadcrumbsList = getBreadcrumbs(hit)
-  const [title, setTitle] = useState<string>('')
   const DocIcon = getIcon(hit.doctype)
-
-  useEffect(() => {
-    if (hit.type === 'content') setTitle(hit.content)
-    else {
-      const hierarchy = JSON.parse(JSON.stringify(hit.hierarchy))
-      setTitle(hierarchy[hit.type])
-    }
-  }, [])
-
   return (
     <Link href={getRelativeURL(hit)} legacyBehavior>
       <a onClick={() => setSearchStateActive({})}>
         <Box sx={styles.hitBox}>
           <Flex>
             {DocIcon && <DocIcon className="hit-icon" sx={styles.hitIcon} />}
-            <Text className="hit-content-title" sx={styles.hitContent}>
-              {title}
-            </Text>
+            <CustomHighlight hit={hit} attribute="content" />
           </Flex>
           <Flex sx={styles.alignCenter}>
             <Text sx={styles.hitBreadCrumbIn}>{`In ${hit.doctype}`}</Text>

--- a/src/components/search-input/styles.ts
+++ b/src/components/search-input/styles.ts
@@ -47,6 +47,10 @@ const hitIcon: SxStyleProp = {
   marginRight: '8px',
 }
 
+const hitContentContainer: SxStyleProp = {
+  width: '100%',
+}
+
 const hitContent: SxStyleProp = {
   color: 'muted.0',
   fontSize: '16px',
@@ -144,6 +148,7 @@ export default {
   seeAll,
   hitBox,
   hitIcon,
+  hitContentContainer,
   hitContent,
   hitBreadCrumb,
   hitBreadCrumbIn,

--- a/src/components/search-input/styles.ts
+++ b/src/components/search-input/styles.ts
@@ -51,7 +51,7 @@ const hitContent: SxStyleProp = {
   color: 'muted.0',
   fontSize: '16px',
   lineHeight: '22px',
-  whiteSpace: 'nowrap',
+  whiteSpace: 'pre',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
 }
@@ -133,6 +133,11 @@ const noResults: SxStyleProp = {
   padding: '12px',
 }
 
+const hitContentHighlighted: SxStyleProp = {
+  ...hitContent,
+  background: '#FFE0EF',
+}
+
 export default {
   resultsContainer,
   resultsBox,
@@ -148,4 +153,5 @@ export default {
   searchContainer,
   alignCenter,
   noResults,
+  hitContentHighlighted,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add highlights to search results

#### What problem is this solving?

Improve the user experience by highlighting the results and showing relevant words.
Go to [this page](https://deploy-preview-183--elated-hoover-5c29bf.netlify.app/) and try to search for something.

#### Screenshots or example usage

|before|after|
|------|------|
|![image](https://user-images.githubusercontent.com/42784961/212772372-f1174326-1e75-43df-8c11-2a735f8ac3c4.png)|![image](https://user-images.githubusercontent.com/42784961/212772322-8558b81f-4423-4fbf-a550-ae682aa42730.png)|

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
