### PR TITLE
fix(sitemap): remove hidden pages from static sitemap and block index…

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,5 +1,31 @@
+/** @type {import('next').NextConfig} */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const fs = require('fs')
 const siteUrl = process.env.NEXT_PUBLIC_DOMAIN_URL
+
 module.exports = {
+  transform: async (config, path) => {
+    const noIndexRegex = /(<meta.*(content="noindex").*\/>)/gm
+    const filepath = `./.next/server/pages/${path}.html`
+
+    if (fs.existsSync(filepath)) {
+      try {
+        const data = await fs.promises.readFile(filepath, 'utf8')
+
+        if (data.match(noIndexRegex)) return null
+      } catch (error) {
+        console.error('err', error)
+      }
+    }
+
+    return {
+      loc: path,
+      changefreq: config.changefreq,
+      priority: config.priority,
+      lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+      alternateRefs: config.alternateRefs ?? [],
+    }
+  },
   siteUrl,
   exclude: ['/404', '/500', '/docs/api-reference*', '/server-sitemap.xml'],
   generateRobotsTxt: true,

--- a/src/pages/docs/guides/[slug].tsx
+++ b/src/pages/docs/guides/[slug].tsx
@@ -99,6 +99,9 @@ const DocumentationPage: NextPage<Props> = ({
       <Head>
         <title>{serialized.frontmatter?.title}</title>
         <meta name="docsearch:doctype" content="Guides" />
+        {serialized.frontmatter?.hidden && (
+          <meta name="robots" content="noindex" />
+        )}
       </Head>
       <APIGuideContextProvider headings={headings}>
         <Flex sx={styles.innerContainer}>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove hidden pages from the sitemap (static pages) and block index searches by web scrapers (google...)

#### How should this be manually tested?

Check hidden pages from [dev-portal-docs](https://github.com/vtexdocs/dev-portal-content/tree/main/docs/guides) and if it appear on sitemap

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
