### PR TITLE
Feat/search filter

### DIFF
--- a/src/components/search-filter-tab-bar/index.tsx
+++ b/src/components/search-filter-tab-bar/index.tsx
@@ -1,0 +1,46 @@
+import { useContext } from 'react'
+import { Flex, Text } from '@vtex/brand-ui'
+
+import type { DocumentationTitle, UpdatesTitle } from 'utils/typings/unionTypes'
+
+import { SearchContext } from 'utils/contexts/search'
+import { documentationData, updatesData } from 'utils/constants'
+
+import styles from './styles'
+
+const SearchFilterTab = ({
+  filter,
+}: {
+  filter: '' | DocumentationTitle | UpdatesTitle
+}) => {
+  const { filterSelectedSection, changeFilterSelectedSection, ocurrenceCount } =
+    useContext(SearchContext)
+
+  return (
+    <Flex
+      sx={styles.tab(filterSelectedSection === filter)}
+      onClick={() => changeFilterSelectedSection(filter)}
+    >
+      <Text sx={styles.tabTitle(filterSelectedSection === filter)}>
+        {filter || 'All Results'}
+      </Text>
+      <Text sx={styles.tabCount}>{ocurrenceCount.get(filter) || 0}</Text>
+    </Flex>
+  )
+}
+
+const SearchFilterTabBar = () => {
+  return (
+    <Flex sx={styles.container}>
+      <SearchFilterTab filter="" />
+      {documentationData.map(({ title }) => (
+        <SearchFilterTab key={title} filter={title} />
+      ))}
+      {updatesData.map(({ title }) => (
+        <SearchFilterTab key={title} filter={title} />
+      ))}
+    </Flex>
+  )
+}
+
+export default SearchFilterTabBar

--- a/src/components/search-filter-tab-bar/styles.ts
+++ b/src/components/search-filter-tab-bar/styles.ts
@@ -1,0 +1,41 @@
+import { SxStyleProp } from '@vtex/brand-ui'
+
+const container: SxStyleProp = {
+  display: ['flex', 'flex', 'flex', 'none'],
+  overflowX: 'scroll',
+  scrollbarWidth: 'none',
+  '::-webkit-scrollbar': {
+    display: 'none',
+  },
+}
+
+const tab: (active: boolean) => SxStyleProp = (active) => ({
+  pt: '8px',
+  pb: '14px',
+  px: '24px',
+  cursor: 'pointer',
+  justifyContent: 'center',
+  alignItems: 'center',
+  borderBottom: `${active ? 2 : 1}px solid #${active ? 'D71D55' : 'DDDDDD'}`,
+  minWidth: 'max-content',
+})
+
+const tabTitle: (active: boolean) => SxStyleProp = (active) => ({
+  fontSize: '14px',
+  fontWeight: '600',
+  lineHeight: '16.38px',
+  whiteSpace: 'nowrap',
+  color: `#${active ? 'D71D55' : '545454'}`,
+})
+
+const tabCount: SxStyleProp = {
+  px: '8px',
+  ml: '2px',
+  fontSize: '12px',
+  fontWeight: '400',
+  lineHeight: '16px',
+  borderRadius: '24px',
+  backgroundColor: '#F8F7FC',
+}
+
+export default { container, tab, tabTitle, tabCount }

--- a/src/components/search-input/results-box.tsx
+++ b/src/components/search-input/results-box.tsx
@@ -66,32 +66,34 @@ const HitsBox = connectStateResults(({ searchState, searchResults }) => {
   return (
     <>
       {searchStateActive?.query && searchResults && (
-        <Box sx={styles.resultsContainer}>
-          <Box sx={searchResults.hits.length && styles.resultsBox}>
-            {searchResults.hits.map(
-              (searchResult, index) =>
-                index < 7 && (
-                  <Hit
-                    key={searchResult.objectID}
-                    hit={searchResult}
-                    setSearchStateActive={setSearchStateActive}
-                  />
-                )
+        <Box sx={styles.resultsOuterContainer}>
+          <Box sx={styles.resultsInnerContainer}>
+            <Box sx={searchResults.hits.length && styles.resultsBox}>
+              {searchResults.hits.map(
+                (searchResult, index) =>
+                  index < 7 && (
+                    <Hit
+                      key={searchResult.objectID}
+                      hit={searchResult}
+                      setSearchStateActive={setSearchStateActive}
+                    />
+                  )
+              )}
+            </Box>
+            {false && searchResults.hits.length > 7 && (
+              <Box
+                sx={styles.seeAll}
+                onClick={() => seeAllSubmit(searchStateActive.query!)}
+              >
+                <Text>See all results</Text>
+              </Box>
+            )}
+            {!searchResults.hits.length && (
+              <Flex sx={styles.noResults}>
+                <Text>{messages['search_input.empty']}</Text>
+              </Flex>
             )}
           </Box>
-          {false && searchResults.hits.length > 7 && (
-            <Box
-              sx={styles.seeAll}
-              onClick={() => seeAllSubmit(searchStateActive.query!)}
-            >
-              <Text>See all results</Text>
-            </Box>
-          )}
-          {!searchResults.hits.length && (
-            <Flex sx={styles.noResults}>
-              <Text>{messages['search_input.empty']}</Text>
-            </Flex>
-          )}
         </Box>
       )}
     </>

--- a/src/components/search-input/styles.ts
+++ b/src/components/search-input/styles.ts
@@ -1,11 +1,15 @@
 import type { SxStyleProp } from '@vtex/brand-ui'
 
-const resultsContainer: SxStyleProp = {
+const resultsOuterContainer: SxStyleProp = {
+  position: 'relative',
+}
+
+const resultsInnerContainer: SxStyleProp = {
+  top: 0,
   position: 'absolute',
-  width: ['288px', '288px', '288px', '288px', '416px', '544px'],
+  width: ['288px', '458px', '458px', '288px', '416px', '544px'],
   border: '1px solid #B9B9B9',
   borderRadius: '0px 0px 4px 4px',
-  top: 'calc(5rem - 18px)',
   background: '#FFFFFF',
 }
 
@@ -115,12 +119,12 @@ const searchContainer: SxStyleProp = {
   cursor: 'pointer',
   ':hover': {
     transition: 'all 0.3s ease-out',
-    width: ['288px', '288px', '288px', '288px', '416px', '544px'],
+    width: ['288px', '458px', '458px', '288px', '416px', '544px'],
     border: '1px solid #3B3B3B',
   },
   ':focus-within': {
     background: '#FFFFFF',
-    width: ['288px', '288px', '288px', '288px', '416px', '544px'],
+    width: ['288px', '458px', '458px', '288px', '416px', '544px'],
     transition: 'all 0.3s ease-out',
     border: '1px solid #3B3B3B',
     boxShadow: '0px 0px 0px 1px #FFFFFF, 0px 0px 0px 3px #B9B9B9',
@@ -143,7 +147,8 @@ const hitContentHighlighted: SxStyleProp = {
 }
 
 export default {
-  resultsContainer,
+  resultsOuterContainer,
+  resultsInnerContainer,
   resultsBox,
   seeAll,
   hitBox,

--- a/src/components/search-results/styles.ts
+++ b/src/components/search-results/styles.ts
@@ -2,12 +2,13 @@ import { SxStyleProp } from '@vtex/brand-ui'
 
 const resultContainer: SxStyleProp = {
   width: ['324px', '544px', '544px', '544px', '720px', '720px', '1400px'],
-  paddingTop: '64px',
+  paddingTop: ['32px', '32px', '32px', '64px'],
   hr: {
     marginTop: '16px',
     marginBottom: '32px',
     borderTop: 'none',
     borderColor: '#DDDDDD',
+    display: ['none', 'none', 'none', 'block'],
   },
 }
 
@@ -15,6 +16,7 @@ const resultText: SxStyleProp = {
   mb: '16px',
   fontSize: '16px',
   lineHeight: '22px',
+  display: ['none', 'none', 'none', 'initial'],
 }
 
 export default {

--- a/src/components/search-sections/styles.ts
+++ b/src/components/search-sections/styles.ts
@@ -1,6 +1,7 @@
 import { SxStyleProp } from '@vtex/brand-ui'
 
 const container: SxStyleProp = {
+  display: ['none', 'none', 'none', 'initial'],
   height: '100%',
   width: '242px',
   border: '1px solid #E7E9EE',

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,12 +1,20 @@
-import { Flex } from '@vtex/brand-ui'
+import { Box, Flex } from '@vtex/brand-ui'
 import styles from 'styles/search-page'
 import SearchSections from 'components/search-sections'
 import SearchContextProvider from 'utils/contexts/search'
 import SearchResults from 'components/search-results'
+import SearchFilterTabBar from 'components/search-filter-tab-bar'
+import SearchInput from 'components/search-input'
 
 const SearchPage = () => {
   return (
     <SearchContextProvider>
+      <Box>
+        <Flex sx={styles.searchBarContainer}>
+          <SearchInput />
+        </Flex>
+        <SearchFilterTabBar />
+      </Box>
       <Flex sx={styles.body}>
         <SearchSections />
         <SearchResults />

--- a/src/styles/search-page.ts
+++ b/src/styles/search-page.ts
@@ -1,10 +1,17 @@
 import { SxStyleProp } from '@vtex/brand-ui'
 
+const searchBarContainer: SxStyleProp = {
+  display: ['flex', 'flex', 'flex', 'none'],
+  justifyContent: 'center',
+  py: '16px',
+}
+
 const body: SxStyleProp = {
   background: '#FFFFFF',
   justifyContent: 'center',
 }
 
 export default {
+  searchBarContainer,
   body,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To add the missing tab bar component to the first three breakpoints of the search page.

#### What problem is this solving?

The layout of the search page in the first three breakpoints isn't correct. There should be a search bar and a tab bar for filtering results.

#### How should this be manually tested?

Go to [this page](https://deploy-preview-193--elated-hoover-5c29bf.netlify.app/search) and try different breakpoints. See if the implemented layout matches the [expected one](https://www.figma.com/file/Lx6sXdrw9KEvtSEKWttmv8/Developer-Portal?node-id=6005%3A411685&t=Vq0Fi6im4YfzsR3v-0).

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
