### PR TITLE
build(package): update rapidoc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.1.7-vtex-9-g9131951"
+      "version": "1.1.8-vtex"
     }
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.1.6-vtex-2-g1787282"
+      "version": "1.1.7-vtex-7-g360feae"
     }
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.1.7-vtex-7-g360feae"
+      "version": "1.1.7-vtex-9-g9131951"
     }
   },
   "resolutions": {


### PR DESCRIPTION
:warning: Review comments should be added to the [corresponding rapidoc PR](https://github.com/vtexdocs/RapiDoc/pull/21).
:warning: This PR should be merged **after** merging the Rapidoc branch and updating the version tag.

#### What is the purpose of this pull request?

To change how the inputs with the URL variables are shown in the Base URL section. Now they are shown by hovering on the URL.

#### What problem is this solving?

The page layout was incorrect.

#### How should this be manually tested?

Open any [API Reference page](https://deploy-preview-194--elated-hoover-5c29bf.netlify.app/docs/api-reference) and check (in all breakpoints) if:
1. The URL is correct
2. The input for the variables appear when you hover on the URL
3. The copy symbol is always visible and changes to a check mark when you click on it
4. The URL is copied correctly
5. The URL changes when the variables change
6. The API Request and Curl are correct

#### Screenshots or example usage

Further information can be found [here](https://www.notion.so/vtexhandbook/Ajustar-componente-de-Base-URL-2c7ce94679db402ca14218eb0ecb306b).
![Captura de tela de 2023-01-20 14-24-07](https://user-images.githubusercontent.com/62757720/213764017-0d192665-263b-4661-9d9a-70f40f88f957.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
