### PR TITLE
fix(navigation): add SKU Service endpoints to navigation.json

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -2811,6 +2811,15 @@
               "type": "category",
               "children": [
                 {
+                  "name": "Get SKU Service",
+                  "slug": "catalog-api",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/api/catalog/pvt/skuservice/-skuServiceId-",
+                  "children": []
+                },
+                {
                   "name": "Update SKU Service",
                   "slug": "catalog-api",
                   "type": "openapi",
@@ -2919,6 +2928,15 @@
                   "method": "POST",
                   "origin": "",
                   "endpoint": "/api/catalog/pvt/skuservicevalue",
+                  "children": []
+                },
+                {
+                  "name": "Get SKU Service Value",
+                  "slug": "catalog-api",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/api/catalog/pvt/skuservicevalue/-skuServiceValueId-",
                   "children": []
                 },
                 {

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -2897,6 +2897,15 @@
                   "children": []
                 },
                 {
+                  "name": "Get SKU Service Type",
+                  "slug": "catalog-api",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/api/catalog/pvt/skuservicetype/-skuServiceTypeId-",
+                  "children": []
+                },
+                {
                   "name": "Update SKU Service Type",
                   "slug": "catalog-api",
                   "type": "openapi",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adding the following Catalog API endpoints to navigation.json:

- [Get SKU Service](https://developers.vtex.com/docs/api-reference/catalog-api#get-/api/catalog/pvt/skuservice/-skuServiceId-)
- [Get SKU Service Value](https://developers.vtex.com/docs/api-reference/catalog-api#get-/api/catalog/pvt/skuservicevalue/-skuServiceValueId-)
- [Get SKU Service Type](https://developers.vtex.com/docs/api-reference/catalog-api#get-/api/catalog/pvt/skuservicetype/-skuServiceTypeId-)

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
