### PR TITLE
docs(navigation): add get gift list endpoint

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -3915,6 +3915,22 @@
                   "children": []
                 }
               ]
+            },
+            {
+              "name": "Gift List",
+              "slug": "catalog-api-gift-list",
+              "type": "category",
+              "children": [
+                {
+                  "name": "Get Gift List",
+                  "slug": "catalog-api",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/api/addon/pvt/giftlist/get/-listId-",
+                  "children": []
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adding the Catalog API - [Get Gift List](https://developers.vtex.com/docs/api-reference/catalog-api#get-/api/addon/pvt/giftlist/get/-listId-) endpoint documentation to navigation.json.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
