### PR TITLE
fix(global.css): create css classes for http methods

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -52,3 +52,38 @@ table th {
 table tbody tr:nth-of-type(even) {
   background-color: #f8f7fc;
 }
+
+.api {
+  box-sizing: border-box;
+  margin: 0px 4px;
+  border: 1px solid #dddddd;
+  background: #f4f4f4;
+  border-radius: 2px;
+  width: max-content;
+  height: 24px;
+  padding-left: 4px;
+  padding-right: 4px;
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.api.type-post {
+  color: #2978b5;
+}
+
+.api.type-get {
+  color: #38853c;
+}
+
+.api.type-put {
+  color: #d56a00;
+}
+
+.api.type-delete {
+  color: #cc3d3d;
+}
+
+.api.type-patch {
+  color: #827717;
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix rendering of the http methods in the api guides.

#### What problem is this solving?

Missing css classes.

#### How should this be manually tested?

Open any API Guide page, such as External seller connector, that contains the keywords (post, get, put, delete, patch) and check if it is highlighted as expected.

#### Screenshots or example usage

![Captura de tela de 2023-01-27 14-00-36](https://user-images.githubusercontent.com/62757720/215150375-679783a3-84a9-4fcb-bed1-ccd5351f596b.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
