### PR TITLE
perf(search-input): stop search with an empty query

### DIFF
--- a/src/components/search-input/index.tsx
+++ b/src/components/search-input/index.tsx
@@ -6,11 +6,20 @@ import Results from './results-box'
 import { Box } from '@vtex/brand-ui'
 import { useRef, useState } from 'react'
 import useClickOutside from 'utils/hooks/useClickOutside'
+import { MultipleQueriesQuery } from '@algolia/client-search'
 
-const searchClient = algoliasearch(
+const algoliaClient = algoliasearch(
   'A4TXCBOC74',
   'bcced196dc1d3b841471e5aa412b62ad'
 )
+
+const searchClient = {
+  ...algoliaClient,
+  search(requests: MultipleQueriesQuery[]) {
+    if (requests.every(({ params }) => !params?.query)) return
+    return algoliaClient.search(requests)
+  },
+}
 
 export default function SearchInput() {
   const [focusOut, setfocusOut] = useState<{ modaltoggle: boolean }>({

--- a/src/components/search-input/results-box.tsx
+++ b/src/components/search-input/results-box.tsx
@@ -65,7 +65,7 @@ const HitsBox = connectStateResults(({ searchState, searchResults }) => {
 
   return (
     <>
-      {searchStateActive?.query && (
+      {searchStateActive?.query && searchResults && (
         <Box sx={styles.resultsContainer}>
           <Box sx={searchResults.hits.length && styles.resultsBox}>
             {searchResults.hits.map(


### PR DESCRIPTION
#### What is the purpose of this pull request?

Stop the search with an empty query

#### What problem is this solving?

On the first page load, the search component creates an empty query to Algolia. This PR aims to reduce the number of unnecessary requests.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
