### PR TITLE
docs(navigation): correct vtex id endpoint (generate authentication t…

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -9322,7 +9322,7 @@
                   "type": "openapi",
                   "method": "POST",
                   "origin": "",
-                  "endpoint": "/vtexid/apptoken/login",
+                  "endpoint": "/api/vtexid/apptoken/login",
                   "children": []
                 }
               ]


### PR DESCRIPTION
Fixed the navigation endpoint for the Generate authentication token was wrong, causing the navigation link to be incorrect.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
