### PR TITLE
Adding guides "List pickup points by location and "Get address by pos…

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -1236,6 +1236,28 @@
                   "children": []
                 }
               ]
+            },
+            {
+              "name": "Fulfillment",
+              "slug": "fulfillment",
+              "origin": "",
+              "type": "markdown",
+              "children": [
+                {
+                  "name": "List pickup points by location",
+                  "slug": "list-pickup-points-by-location",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
+                  "name": "Get address by postal code",
+                  "slug": "get-address-by-postal-code",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
Adding guides "List pickup points by location and "Get address by postal code" to the side bar.

#### What is the purpose of this pull request?

Add two guides references to the side bar:
- List pickup points by location (https://developers.vtex.com/docs/guides/list-pickup-points-by-location)
- Get address by postal code (https://developers.vtex.com/docs/guides/get-address-by-postal-code)

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
