### PR TITLE
build: update rapidoc version to fix curly brackets

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.2.0-vtex"
+      "version": "1.2.0-vtex-3-gc46065b"
     }
   },
   "resolutions": {


### PR DESCRIPTION
:warning: Review comments should be added to the [corresponding RapiDoc PR](https://github.com/vtexdocs/RapiDoc/pull/25).
:warning: This PR should be merged after merging the Rapidoc branch and updating the version tag.

#### What is the purpose of this pull request?

Decode curly brackets contained in the base url variables.

#### What problem is this solving?

The cURL example did not show the curly brackets.

#### How should this be manually tested?

Open any API Reference page that has variables in the base URL and check if the url in the cURL example shows the curly brackets from the variables names.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
