### PR TITLE
Feat/mobile menu

### DIFF
--- a/src/components/announcement-bar/styles.ts
+++ b/src/components/announcement-bar/styles.ts
@@ -7,7 +7,7 @@ const container: SxStyleProp = {
   justifyContent: 'space-between',
   cursor: 'default',
   width: '100%',
-  padding: '15px 50px ',
+  padding: ['15px 15px', '15px 25px', '15px 50px'],
   ':focus': {
     outline: 'none',
   },
@@ -49,7 +49,7 @@ const link: SxStyleProp = {
 }
 
 const closeIcon: SxStyleProp = {
-  display: ['none', 'none', 'block'],
+  display: 'block',
   float: 'right',
 }
 

--- a/src/components/documentation-card/index.tsx
+++ b/src/components/documentation-card/index.tsx
@@ -4,12 +4,14 @@ import { Box, Flex, Text } from '@vtex/brand-ui'
 import styles from './styles'
 import { cardContainer, cardTitle, titleContainer } from './functions'
 import { DataElement } from 'utils/typings/types'
+import { MouseEventHandler } from 'react'
 
 export interface DocumentProps extends DataElement {
   title: string
 }
 export interface CardProps extends DocumentProps {
   containerType: 'dropdown' | 'see-also' | 'mobile'
+  onClick?: MouseEventHandler<HTMLAnchorElement> | undefined
 }
 const DocumentationCard = ({
   title,
@@ -17,20 +19,23 @@ const DocumentationCard = ({
   link,
   containerType,
   Icon,
+  onClick,
 }: CardProps) => {
   return (
     <Link href={link} legacyBehavior>
-      <Box sx={cardContainer(containerType)}>
-        <Flex sx={titleContainer(containerType)}>
-          <Icon size={24} />
-          <Text className="title" sx={cardTitle(containerType)}>
-            {title}
+      <a onClick={onClick}>
+        <Box sx={cardContainer(containerType)}>
+          <Flex sx={titleContainer(containerType)}>
+            <Icon size={24} />
+            <Text className="title" sx={cardTitle(containerType)}>
+              {title}
+            </Text>
+          </Flex>
+          <Text className="description" sx={styles.description}>
+            {description}
           </Text>
-        </Flex>
-        <Text className="description" sx={styles.description}>
-          {description}
-        </Text>
-      </Box>
+        </Box>
+      </a>
     </Link>
   )
 }

--- a/src/components/header/hamburger-menu.tsx
+++ b/src/components/header/hamburger-menu.tsx
@@ -4,22 +4,32 @@ import styles from './styles'
 import DocumentationCard from 'components/documentation-card'
 import { documentationData, updatesData } from 'utils/constants'
 import SidebarSection, { SidebarSectionProps } from 'components/sidebar-section'
-import { useContext, useState } from 'react'
+import { useContext, useEffect } from 'react'
 import { SidebarContext } from 'utils/contexts/sidebar'
 
 const HamburgerMenu = ({ sectionSelected = 'API Reference' }) => {
-  const [activeSectionName, setActiveSectionName] = useState(sectionSelected)
-  const { sidebarDataMaster, sidebarSectionHidden, setSidebarSectionHidden } =
-    useContext(SidebarContext)
+  const {
+    sidebarDataMaster,
+    sidebarSectionHidden,
+    activeSidebarElement,
+    setActiveSidebarElement,
+    setSidebarSectionHidden,
+  } = useContext(SidebarContext)
+
+  useEffect(() => {
+    if (!activeSidebarElement) {
+      setActiveSidebarElement(sectionSelected)
+    }
+  }, [activeSidebarElement])
 
   return (
     <Header.ActionButton>
-      <VtexHamburgerMenu
-        sx={styles.hamburgerContainer}
-        className={sidebarSectionHidden ? '' : 'menuHidden'}
-      >
-        <VtexHamburgerMenu.Menu>
-          <Box sx={styles.menuContainer}>
+      <VtexHamburgerMenu sx={styles.hamburgerContainer}>
+        <VtexHamburgerMenu.Menu sx={styles.noPadding}>
+          <Box
+            sx={styles.menuContainer}
+            className={sidebarSectionHidden ? '' : 'menuHidden'}
+          >
             <Box sx={styles.cardContainer}>
               <Box
                 sx={styles.documentationContainer}
@@ -31,7 +41,7 @@ const HamburgerMenu = ({ sectionSelected = 'API Reference' }) => {
                     key={card.title}
                     {...card}
                     onClick={() => {
-                      setActiveSectionName(card.title)
+                      setActiveSidebarElement(card.title)
                       setSidebarSectionHidden(false)
                     }}
                   />
@@ -51,12 +61,13 @@ const HamburgerMenu = ({ sectionSelected = 'API Reference' }) => {
               </Box>
             </Box>
             <Box sx={styles.sideMenuContainer}>
-              {activeSectionName ? (
+              {activeSidebarElement ? (
                 <SidebarSection
+                  isHamburgerMenu={true}
                   {...(Array.isArray(sidebarDataMaster)
                     ? sidebarDataMaster?.find(
                         (section: SidebarSectionProps) =>
-                          section.documentation === activeSectionName
+                          section.documentation === activeSidebarElement
                       )
                     : null)}
                 />

--- a/src/components/header/hamburger-menu.tsx
+++ b/src/components/header/hamburger-menu.tsx
@@ -11,16 +11,16 @@ const HamburgerMenu = ({ sectionSelected = 'API Reference' }) => {
   const {
     sidebarDataMaster,
     sidebarSectionHidden,
-    activeSidebarElement,
-    setActiveSidebarElement,
+    activeSidebarTab,
+    setActiveSidebarTab,
     setSidebarSectionHidden,
   } = useContext(SidebarContext)
 
   useEffect(() => {
-    if (!activeSidebarElement) {
-      setActiveSidebarElement(sectionSelected)
+    if (!activeSidebarTab) {
+      setActiveSidebarTab(sectionSelected)
     }
-  }, [activeSidebarElement])
+  }, [activeSidebarTab])
 
   return (
     <Header.ActionButton>
@@ -41,7 +41,7 @@ const HamburgerMenu = ({ sectionSelected = 'API Reference' }) => {
                     key={card.title}
                     {...card}
                     onClick={() => {
-                      setActiveSidebarElement(card.title)
+                      setActiveSidebarTab(card.title)
                       setSidebarSectionHidden(false)
                     }}
                   />
@@ -61,13 +61,13 @@ const HamburgerMenu = ({ sectionSelected = 'API Reference' }) => {
               </Box>
             </Box>
             <Box sx={styles.sideMenuContainer}>
-              {activeSidebarElement ? (
+              {activeSidebarTab ? (
                 <SidebarSection
                   isHamburgerMenu={true}
                   {...(Array.isArray(sidebarDataMaster)
                     ? sidebarDataMaster?.find(
                         (section: SidebarSectionProps) =>
-                          section.documentation === activeSidebarElement
+                          section.documentation === activeSidebarTab
                       )
                     : null)}
                 />

--- a/src/components/header/hamburger-menu.tsx
+++ b/src/components/header/hamburger-menu.tsx
@@ -25,7 +25,7 @@ const HamburgerMenu = ({ sectionSelected = 'API Reference' }) => {
   return (
     <Header.ActionButton>
       <VtexHamburgerMenu sx={styles.hamburgerContainer}>
-        <VtexHamburgerMenu.Menu sx={styles.noPadding}>
+        <VtexHamburgerMenu.Menu sx={styles.innerHambugerContainer}>
           <Box
             sx={styles.menuContainer}
             className={sidebarSectionHidden ? '' : 'menuHidden'}

--- a/src/components/header/hamburger-menu.tsx
+++ b/src/components/header/hamburger-menu.tsx
@@ -3,34 +3,65 @@ import styles from './styles'
 
 import DocumentationCard from 'components/documentation-card'
 import { documentationData, updatesData } from 'utils/constants'
-const HamburgerMenu = () => {
+import SidebarSection, { SidebarSectionProps } from 'components/sidebar-section'
+import { useContext, useState } from 'react'
+import { SidebarContext } from 'utils/contexts/sidebar'
+
+const HamburgerMenu = ({ sectionSelected = 'API Reference' }) => {
+  const [activeSectionName, setActiveSectionName] = useState(sectionSelected)
+  const { sidebarDataMaster, sidebarSectionHidden, setSidebarSectionHidden } =
+    useContext(SidebarContext)
+
   return (
     <Header.ActionButton>
-      <VtexHamburgerMenu sx={styles.hamburgerContainer}>
+      <VtexHamburgerMenu
+        sx={styles.hamburgerContainer}
+        className={sidebarSectionHidden ? '' : 'menuHidden'}
+      >
         <VtexHamburgerMenu.Menu>
-          <Box
-            sx={styles.documentationContainer}
-            data-cy="dropdown-menu-first-section"
-          >
-            {documentationData.map((card) => (
-              <DocumentationCard
-                containerType="mobile"
-                key={card.title}
-                {...card}
-              />
-            ))}
-          </Box>
-          <Box
-            sx={styles.updatesContainer}
-            data-cy="dropdown-menu-second-section"
-          >
-            {updatesData.map((card) => (
-              <DocumentationCard
-                containerType="mobile"
-                key={card.title}
-                {...card}
-              />
-            ))}
+          <Box sx={styles.menuContainer}>
+            <Box sx={styles.cardContainer}>
+              <Box
+                sx={styles.documentationContainer}
+                data-cy="dropdown-menu-first-section"
+              >
+                {documentationData.map((card) => (
+                  <DocumentationCard
+                    containerType="mobile"
+                    key={card.title}
+                    {...card}
+                    onClick={() => {
+                      setActiveSectionName(card.title)
+                      setSidebarSectionHidden(false)
+                    }}
+                  />
+                ))}
+              </Box>
+              <Box
+                sx={styles.updatesContainer}
+                data-cy="dropdown-menu-second-section"
+              >
+                {updatesData.map((card) => (
+                  <DocumentationCard
+                    containerType="mobile"
+                    key={card.title}
+                    {...card}
+                  />
+                ))}
+              </Box>
+            </Box>
+            <Box sx={styles.sideMenuContainer}>
+              {activeSectionName ? (
+                <SidebarSection
+                  {...(Array.isArray(sidebarDataMaster)
+                    ? sidebarDataMaster?.find(
+                        (section: SidebarSectionProps) =>
+                          section.documentation === activeSectionName
+                      )
+                    : null)}
+                />
+              ) : null}
+            </Box>
           </Box>
         </VtexHamburgerMenu.Menu>
       </VtexHamburgerMenu>

--- a/src/components/header/hamburger-menu.tsx
+++ b/src/components/header/hamburger-menu.tsx
@@ -1,4 +1,10 @@
-import { Header, HamburgerMenu as VtexHamburgerMenu, Box } from '@vtex/brand-ui'
+import {
+  Header,
+  HamburgerMenu as VtexHamburgerMenu,
+  Box,
+  IconCaret,
+  Button,
+} from '@vtex/brand-ui'
 import styles from './styles'
 
 import DocumentationCard from 'components/documentation-card'
@@ -20,27 +26,35 @@ const HamburgerMenu = () => {
     <Header.ActionButton>
       <VtexHamburgerMenu sx={styles.hamburgerContainer}>
         <VtexHamburgerMenu.Menu sx={styles.innerHambugerContainer}>
-          <Box
-            sx={styles.menuContainer}
-            className={
-              sidebarSectionHidden || !activeSidebarTab ? '' : 'menuHidden'
-            }
-          >
+          <Box sx={styles.menuContainer}>
             <Box sx={styles.cardContainer}>
               <Box
                 sx={styles.documentationContainer}
                 data-cy="dropdown-menu-first-section"
               >
                 {documentationData.map((card) => (
-                  <DocumentationCard
-                    containerType="mobile"
-                    key={card.title}
-                    {...card}
-                    onClick={() => {
-                      setActiveSidebarTab(card.title)
-                      setSidebarSectionHidden(false)
-                    }}
-                  />
+                  <Box sx={styles.innerCardContainer}>
+                    <DocumentationCard
+                      containerType="mobile"
+                      key={card.title}
+                      {...card}
+                    />
+                    <Button
+                      aria-label={'Open sidebar'}
+                      size="regular"
+                      variant="tertiary"
+                      icon={() => <IconCaret direction="right" size={24} />}
+                      sx={
+                        activeSidebarTab === card.title && !sidebarSectionHidden
+                          ? styles.arrowIconActive
+                          : styles.arrowIcon
+                      }
+                      onClick={() => {
+                        setActiveSidebarTab(card.title)
+                        setSidebarSectionHidden(false)
+                      }}
+                    />
+                  </Box>
                 ))}
               </Box>
               <Box
@@ -48,15 +62,33 @@ const HamburgerMenu = () => {
                 data-cy="dropdown-menu-second-section"
               >
                 {updatesData.map((card) => (
-                  <DocumentationCard
-                    containerType="mobile"
-                    key={card.title}
-                    {...card}
-                  />
+                  <Box sx={styles.innerCardContainer}>
+                    <DocumentationCard
+                      containerType="mobile"
+                      key={card.title}
+                      {...card}
+                    />
+                    <Button
+                      aria-label={'Open sidebar'}
+                      size="regular"
+                      variant="tertiary"
+                      icon={() => <IconCaret direction="right" size={24} />}
+                      sx={styles.arrowIcon}
+                      onClick={() => {
+                        setActiveSidebarTab(card.title)
+                        setSidebarSectionHidden(false)
+                      }}
+                    />
+                  </Box>
                 ))}
               </Box>
             </Box>
-            <Box sx={styles.sideMenuContainer}>
+            <Box
+              className={
+                sidebarSectionHidden || !activeSidebarTab ? '' : 'menuHidden'
+              }
+              sx={styles.sideMenuContainer}
+            >
               {activeSidebarTab ? (
                 <SidebarSection
                   isHamburgerMenu={true}

--- a/src/components/header/hamburger-menu.tsx
+++ b/src/components/header/hamburger-menu.tsx
@@ -4,10 +4,10 @@ import styles from './styles'
 import DocumentationCard from 'components/documentation-card'
 import { documentationData, updatesData } from 'utils/constants'
 import SidebarSection, { SidebarSectionProps } from 'components/sidebar-section'
-import { useContext, useEffect } from 'react'
+import { useContext } from 'react'
 import { SidebarContext } from 'utils/contexts/sidebar'
 
-const HamburgerMenu = ({ sectionSelected = 'API Reference' }) => {
+const HamburgerMenu = () => {
   const {
     sidebarDataMaster,
     sidebarSectionHidden,
@@ -16,19 +16,15 @@ const HamburgerMenu = ({ sectionSelected = 'API Reference' }) => {
     setSidebarSectionHidden,
   } = useContext(SidebarContext)
 
-  useEffect(() => {
-    if (!activeSidebarTab) {
-      setActiveSidebarTab(sectionSelected)
-    }
-  }, [activeSidebarTab])
-
   return (
     <Header.ActionButton>
       <VtexHamburgerMenu sx={styles.hamburgerContainer}>
         <VtexHamburgerMenu.Menu sx={styles.innerHambugerContainer}>
           <Box
             sx={styles.menuContainer}
-            className={sidebarSectionHidden ? '' : 'menuHidden'}
+            className={
+              sidebarSectionHidden || !activeSidebarTab ? '' : 'menuHidden'
+            }
           >
             <Box sx={styles.cardContainer}>
               <Box

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -21,14 +21,9 @@ import SearchInput from 'components/search-input'
 import AnnouncementBar from 'components/announcement-bar'
 
 import styles from './styles'
-import { DocumentationTitle, UpdatesTitle } from 'utils/typings/unionTypes'
-
-interface SideBarSectionState {
-  sectionSelected?: DocumentationTitle | UpdatesTitle | ''
-}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const Header = ({ sectionSelected = 'API Reference' }: SideBarSectionState) => {
+const Header = () => {
   const router = useRouter()
 
   const lastScroll = useRef(0)
@@ -139,7 +134,7 @@ const Header = ({ sectionSelected = 'API Reference' }: SideBarSectionState) => {
             </Text>
           </VtexLink>
         </HeaderBrand.RightLinks>
-        <HamburgerMenu sectionSelected={sectionSelected} />
+        <HamburgerMenu />
       </HeaderBrand>
     </Box>
   )

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -21,8 +21,14 @@ import SearchInput from 'components/search-input'
 import AnnouncementBar from 'components/announcement-bar'
 
 import styles from './styles'
+import { DocumentationTitle, UpdatesTitle } from 'utils/typings/unionTypes'
 
-const Header = () => {
+interface SideBarSectionState {
+  sectionSelected?: DocumentationTitle | UpdatesTitle | ''
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Header = ({ sectionSelected = 'API Reference' }: SideBarSectionState) => {
   const router = useRouter()
 
   const lastScroll = useRef(0)
@@ -133,7 +139,7 @@ const Header = () => {
             </Text>
           </VtexLink>
         </HeaderBrand.RightLinks>
-        <HamburgerMenu />
+        <HamburgerMenu sectionSelected={sectionSelected} />
       </HeaderBrand>
     </Box>
   )

--- a/src/components/header/styles.ts
+++ b/src/components/header/styles.ts
@@ -3,6 +3,9 @@ import type { SxStyleProp } from '@vtex/brand-ui'
 const menuContainer: SxStyleProp = {
   display: 'flex',
   width: 'max-content',
+  position: 'relative',
+  transition: '1s',
+  left: 0,
 }
 
 const cardContainer: SxStyleProp = {
@@ -28,9 +31,8 @@ const headerContainer: SxStyleProp = {
 const hamburgerContainer: SxStyleProp = {
   backgroundColor: '#ffff',
   width: '100%',
-  postition: 'relative',
-  left: 0,
   '.menuHidden': {
+    transition: '1s',
     left: '-100vw',
   },
 }
@@ -143,6 +145,10 @@ const updatesContainer: SxStyleProp = {
   borderTop: '1px solid #E7E9EE',
 }
 
+const noPadding: SxStyleProp = {
+  padding: '0px',
+}
+
 export default {
   menuContainer,
   cardContainer,
@@ -162,4 +168,5 @@ export default {
   documentationContainer,
   updatesContainer,
   hamburgerContainer,
+  noPadding,
 }

--- a/src/components/header/styles.ts
+++ b/src/components/header/styles.ts
@@ -1,5 +1,23 @@
 import type { SxStyleProp } from '@vtex/brand-ui'
 
+const menuContainer: SxStyleProp = {
+  display: 'flex',
+  width: 'max-content',
+}
+
+const cardContainer: SxStyleProp = {
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100vw',
+}
+
+const sideMenuContainer: SxStyleProp = {
+  height: 'calc(100vh - 5rem)',
+  width: '100vw',
+  overflowY: 'auto',
+  overflowX: 'hidden',
+}
+
 const headerContainer: SxStyleProp = {
   position: 'sticky',
   zIndex: 9999,
@@ -10,6 +28,11 @@ const headerContainer: SxStyleProp = {
 const hamburgerContainer: SxStyleProp = {
   backgroundColor: '#ffff',
   width: '100%',
+  postition: 'relative',
+  left: 0,
+  '.menuHidden': {
+    left: '-100vw',
+  },
 }
 
 const headerBrand: SxStyleProp = {
@@ -121,6 +144,9 @@ const updatesContainer: SxStyleProp = {
 }
 
 export default {
+  menuContainer,
+  cardContainer,
+  sideMenuContainer,
   logoSize,
   headerContainer,
   headerBrand,

--- a/src/components/header/styles.ts
+++ b/src/components/header/styles.ts
@@ -3,9 +3,6 @@ import type { SxStyleProp } from '@vtex/brand-ui'
 const menuContainer: SxStyleProp = {
   display: 'flex',
   width: 'max-content',
-  position: 'relative',
-  transition: '1s',
-  left: 0,
 }
 
 const cardContainer: SxStyleProp = {
@@ -15,10 +12,13 @@ const cardContainer: SxStyleProp = {
 }
 
 const sideMenuContainer: SxStyleProp = {
+  backgroundColor: '#ffff',
   height: 'calc(100vh - 5rem)',
   width: '100vw',
   overflowY: 'auto',
   overflowX: 'hidden',
+  transform: 'translate(0)',
+  transition: 'transform .5s cubic-bezier(.4,0,.2,1)',
 }
 
 const headerContainer: SxStyleProp = {
@@ -32,8 +32,7 @@ const hamburgerContainer: SxStyleProp = {
   backgroundColor: '#ffff',
   width: '100%',
   '.menuHidden': {
-    transition: '1s',
-    left: '-100vw',
+    transform: 'translate(-100%)',
   },
 }
 
@@ -151,6 +150,22 @@ const innerHambugerContainer: SxStyleProp = {
   overflowX: 'hidden',
 }
 
+const innerCardContainer: SxStyleProp = {
+  display: 'flex',
+  alignItems: 'center',
+}
+
+const arrowIcon: SxStyleProp = {
+  padding: '0',
+  height: '34px',
+  color: 'muted.1',
+}
+
+const arrowIconActive: SxStyleProp = {
+  ...arrowIcon,
+  color: '#D71D55',
+}
+
 export default {
   menuContainer,
   cardContainer,
@@ -171,4 +186,7 @@ export default {
   updatesContainer,
   hamburgerContainer,
   innerHambugerContainer,
+  innerCardContainer,
+  arrowIcon,
+  arrowIconActive,
 }

--- a/src/components/header/styles.ts
+++ b/src/components/header/styles.ts
@@ -145,8 +145,10 @@ const updatesContainer: SxStyleProp = {
   borderTop: '1px solid #E7E9EE',
 }
 
-const noPadding: SxStyleProp = {
+const innerHambugerContainer: SxStyleProp = {
   padding: '0px',
+  position: 'relative',
+  overflowX: 'hidden',
 }
 
 export default {
@@ -168,5 +170,5 @@ export default {
   documentationContainer,
   updatesContainer,
   hamburgerContainer,
-  noPadding,
+  innerHambugerContainer,
 }

--- a/src/components/icons/arrow-left-icon.tsx
+++ b/src/components/icons/arrow-left-icon.tsx
@@ -1,0 +1,29 @@
+import type { IconProps } from '@vtex/brand-ui'
+import { Icon } from '@vtex/brand-ui'
+
+const ArrowLeftIcon = (props: IconProps) => (
+  <Icon
+    {...props}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    {' '}
+    <path
+      d="M19.5195 12.0195L4.52953 12.0195"
+      stroke="#4A596B"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M10.5176 18.0117L4.48058 11.9997L10.5176 5.98772"
+      stroke="#4A596B"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </Icon>
+)
+
+export default ArrowLeftIcon

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -47,7 +47,6 @@ export default function Layout({
         width="0"
         style={{ display: 'none', visibility: 'hidden' }}
       ></iframe>
-      <Header />
       <div className="container">
         <Script
           src="https://www.googletagmanager.com/gtag/js?id=UA-56275648-4"
@@ -70,8 +69,9 @@ export default function Layout({
 					`}
         </Script>
       </div>
-      <Flex sx={styles.container}>
-        <SidebarContextProvider fallback={sidebarfallback}>
+      <SidebarContextProvider fallback={sidebarfallback}>
+        <Header sectionSelected={sectionSelected} />
+        <Flex sx={styles.container}>
           {!hideSidebar && (
             <Sidebar
               parentsArray={parentsArray}
@@ -79,8 +79,8 @@ export default function Layout({
             />
           )}
           <Box sx={styles.mainContainer}>{children}</Box>
-        </SidebarContextProvider>
-      </Flex>
+        </Flex>
+      </SidebarContextProvider>
       <Footer />
     </ThemeProvider>
   )

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -70,7 +70,7 @@ export default function Layout({
         </Script>
       </div>
       <SidebarContextProvider fallback={sidebarfallback}>
-        <Header sectionSelected={sectionSelected} />
+        <Header />
         <Flex sx={styles.container}>
           {!hideSidebar && (
             <Sidebar

--- a/src/components/sidebar-section/index.tsx
+++ b/src/components/sidebar-section/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, Box, Text } from '@vtex/brand-ui'
+import { Flex, Box, Text, Button } from '@vtex/brand-ui'
 import { useContext, useEffect, useMemo, useState } from 'react'
 
 import type { SidebarElement } from 'components/sidebar-elements'
@@ -12,8 +12,10 @@ import SearchIcon from 'components/icons/search-icon'
 import SideBarToggleIcon from 'components/icons/sidebar-toggle-icon'
 import SideBarElements from 'components/sidebar-elements'
 import SectionFilter from 'components/sidebar-section-filter'
+import ArrowLeftIcon from 'components/icons/arrow-left-icon'
 
 import { SidebarContext } from 'utils/contexts/sidebar'
+import { getIcon } from 'utils/constants'
 
 import styles from './styles'
 
@@ -21,12 +23,14 @@ export interface SidebarSectionProps {
   documentation: DocumentationTitle | UpdatesTitle
   categories: SidebarElement[]
   slugPrefix: SlugPrefix
+  isHamburgerMenu: boolean
 }
 
 const SidebarSection = ({
   documentation,
   categories,
   slugPrefix,
+  isHamburgerMenu = false,
 }: SidebarSectionProps) => {
   const [searchValue, setSearchValue] = useState('')
   const { sidebarSectionHidden, setSidebarSectionHidden } =
@@ -84,7 +88,60 @@ const SidebarSection = ({
     return filteredCategories
   }, [filterStatus, methodFilterList, categories, searchValue])
 
-  return (
+  const DocIcon = getIcon(documentation)
+
+  return isHamburgerMenu ? (
+    <Box
+      className={sidebarSectionHidden ? 'active' : ''}
+      sx={styles.sidebarContainerHamburger}
+    >
+      <Box
+        className={sidebarSectionHidden ? 'sidebarHide' : ''}
+        sx={styles.sidebarContainerBox}
+      >
+        <Flex sx={styles.sidebarContainerTitle}>
+          <Button
+            sx={styles.arrowButton}
+            aria-label={'Go back'}
+            size="small"
+            variant="tertiary"
+            icon={() => <ArrowLeftIcon size={24} />}
+            onClick={() => {
+              setSidebarSectionHidden(true)
+            }}
+          />
+          {DocIcon && <DocIcon />}
+          <Text sx={styles.sidebarTitle}>{documentation}</Text>
+        </Flex>
+        <Box sx={styles.sidebarContainerBody}>
+          <Flex sx={styles.searchBox}>
+            <SearchIcon sx={styles.searchIcon} />
+            <input
+              style={styles.searchInput}
+              className="searchComponent"
+              type="text"
+              placeholder={`Search in ${documentation}...`}
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.currentTarget.value)}
+            />
+          </Flex>
+          {documentation == 'API Reference' && (
+            <SectionFilter
+              methodFilterList={methodFilterList}
+              setMethodFilter={setMethodFilterList}
+            />
+          )}
+        </Box>
+        <Box sx={styles.sidebarContainerBody}>
+          <SideBarElements
+            items={filteredResult}
+            subItemLevel={0}
+            slugPrefix={slugPrefix}
+          />
+        </Box>
+      </Box>
+    </Box>
+  ) : (
     <Box
       className={sidebarSectionHidden ? 'active' : ''}
       sx={styles.sidebarContainer}

--- a/src/components/sidebar-section/styles.ts
+++ b/src/components/sidebar-section/styles.ts
@@ -26,6 +26,12 @@ const sidebarContainer: SxStyleProp = {
   },
 }
 
+const sidebarContainerHamburger: SxStyleProp = {
+  width: 'auto',
+  minHeight: '692px',
+  zIndex: '1',
+}
+
 const sidebarContainerBox: SxStyleProp = {
   opacity: '100',
   transition: 'all 1s ease-out',
@@ -37,6 +43,14 @@ const sidebarContainerBody: SxStyleProp = {
 
 const sidebarContainerHeader: SxStyleProp = {
   ...sidebarContainerBody,
+}
+
+const sidebarContainerTitle: SxStyleProp = {
+  alignItems: 'center',
+  lineHeight: '22px',
+  gap: '5px',
+  padding: '17px 0px 17px 17px',
+  borderBottom: '1px solid #E7E9EE',
 }
 
 const sidebarTitle: SxStyleProp = {
@@ -102,11 +116,17 @@ const toggleIcon: SxStyleProp = {
   transform: 'scaleX(-1)',
 }
 
+const arrowButton: SxStyleProp = {
+  padding: '0px',
+}
+
 export default {
   sidebarContainer,
+  sidebarContainerHamburger,
   sidebarContainerBox,
   sidebarContainerBody,
   sidebarContainerHeader,
+  sidebarContainerTitle,
   sidebarTitle,
   sidebarHelpIcon,
   searchBox,
@@ -115,4 +135,5 @@ export default {
   toggleIconBox,
   toggleIconBoxActive,
   toggleIcon,
+  arrowButton,
 }

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -35,7 +35,6 @@ const Sidebar = ({
     activeSidebarElement,
     sidebarDataMaster,
     setSidebarDataMaster,
-    setActiveSidebarElement,
     openSidebarElement,
     closeSidebarElements,
   } = useContext(SidebarContext)
@@ -70,7 +69,6 @@ const Sidebar = ({
     parentsArray.forEach((slug: string) => {
       openSidebarElement(slug)
     })
-    setActiveSidebarElement(activeSlug)
     return () => {
       clearTimeout(timer)
     }

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -35,6 +35,7 @@ const Sidebar = ({
     activeSidebarElement,
     sidebarDataMaster,
     setSidebarDataMaster,
+    setActiveSidebarElement,
     openSidebarElement,
     closeSidebarElements,
   } = useContext(SidebarContext)
@@ -69,6 +70,7 @@ const Sidebar = ({
     parentsArray.forEach((slug: string) => {
       openSidebarElement(slug)
     })
+    setActiveSidebarElement(activeSlug)
     return () => {
       clearTimeout(timer)
     }

--- a/src/utils/contexts/sidebar.tsx
+++ b/src/utils/contexts/sidebar.tsx
@@ -5,6 +5,7 @@ import { SWRConfig } from 'swr'
 type ContextType = {
   sidebarSectionHidden: boolean
   activeSidebarElement: string
+  activeSidebarTab: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sidebarDataMaster: any
   sidebarElementStatus: Map<string, boolean>
@@ -12,6 +13,7 @@ type ContextType = {
   setSidebarDataMaster: Dispatch<SetStateAction<any>>
   setSidebarSectionHidden: Dispatch<SetStateAction<boolean>>
   setActiveSidebarElement: Dispatch<SetStateAction<string>>
+  setActiveSidebarTab: Dispatch<SetStateAction<string>>
   toggleSidebarElementStatus: (title: string) => void
   openSidebarElement: (title: string) => void
   closeSidebarElements: (parentsArray: string[]) => void
@@ -20,11 +22,13 @@ type ContextType = {
 export const SidebarContext = createContext<ContextType>({
   sidebarSectionHidden: false,
   activeSidebarElement: '',
+  activeSidebarTab: '',
   sidebarDataMaster: {},
   sidebarElementStatus: new Map(),
   setSidebarDataMaster: () => undefined,
   setSidebarSectionHidden: () => undefined,
   setActiveSidebarElement: () => undefined,
+  setActiveSidebarTab: () => undefined,
   toggleSidebarElementStatus: () => undefined,
   openSidebarElement: () => undefined,
   closeSidebarElements: () => undefined,
@@ -38,6 +42,7 @@ interface Props extends Partial<ContextType> {
 const SidebarContextProvider = ({ children, ...props }: Props) => {
   const [sidebarSectionHidden, setSidebarSectionHidden] = useState(false)
   const [activeSidebarElement, setActiveSidebarElement] = useState('')
+  const [activeSidebarTab, setActiveSidebarTab] = useState('')
   const [sidebarElementStatus, setSidebarElementStatus] = useState(new Map())
   const [sidebarDataMaster, setSidebarDataMaster] = useState(props.fallback)
 
@@ -75,9 +80,11 @@ const SidebarContextProvider = ({ children, ...props }: Props) => {
       value={{
         sidebarSectionHidden,
         activeSidebarElement,
+        activeSidebarTab,
         sidebarElementStatus,
         setSidebarSectionHidden,
         setActiveSidebarElement,
+        setActiveSidebarTab,
         toggleSidebarElementStatus,
         openSidebarElement,
         closeSidebarElements,


### PR DESCRIPTION
#### What is the purpose of this pull request?

To update the hamburger menu to show all pages that can be selected. Add the sidebar to the hamburger menu.

#### What problem is this solving?

It was not possible to browse the portal in the mobile version. And the announcement could not be closed in the mobile version.

#### How should this be manually tested?

Open the [preview](https://deploy-preview-248--elated-hoover-5c29bf.netlify.app) and browse the portal using the hamburger menu (The menu still does not close after selecting one page, this will be implemented later with other fixes). Also check if the desktop version works the same. 

#### Screenshots or example usage

![Captura de tela de 2023-02-15 16-17-58](https://user-images.githubusercontent.com/62757720/219392082-1c10432b-700e-4b86-aa8a-5311c0a46d2e.png)
![Captura de tela de 2023-02-15 16-17-44](https://user-images.githubusercontent.com/62757720/219392094-3edb7cda-7a4a-4102-9547-c33eca04d02c.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
