### PR TITLE
Fix/mobile overflow

### DIFF
--- a/src/components/markdown-renderer/styles.module.css
+++ b/src/components/markdown-renderer/styles.module.css
@@ -21,6 +21,11 @@
   margin: 0;
   padding: 0.2em 0.4em;
   font-size: 0.875em;
+  word-break: break-all;
+}
+
+table .code {
+  word-break: normal;
 }
 
 .blockquote {

--- a/src/styles/documentation-page.ts
+++ b/src/styles/documentation-page.ts
@@ -31,6 +31,7 @@ const articleBox: SxStyleProp = {
     fontSize: '1.75em',
     fontWeight: '400',
     lineHeight: '2.375em',
+    overflowWrap: 'anywhere',
   },
   h2: {
     fontSize: '1.375em',
@@ -39,6 +40,7 @@ const articleBox: SxStyleProp = {
     marginY: '1.125em',
     paddingTop: '90px',
     marginTop: '-90px',
+    overflowWrap: 'anywhere',
   },
   h3: {
     fontSize: '1.125em',
@@ -46,9 +48,11 @@ const articleBox: SxStyleProp = {
     lineHeight: '1.875em',
     paddingTop: '90px',
     marginTop: '-90px',
+    overflowWrap: 'anywhere',
   },
   strong: {
     fontWeight: '600',
+    overflowWrap: 'anywhere',
   },
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,6 +29,16 @@ footer > div {
   outline: none;
 }
 
+img,
+svg {
+  max-width: 100%;
+  height: auto;
+}
+
+iframe {
+  max-width: 100%;
+}
+
 pre {
   overflow-x: auto;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,6 +29,10 @@ footer > div {
   outline: none;
 }
 
+pre {
+  overflow-x: auto;
+}
+
 table {
   border-collapse: collapse;
   max-width: 100%;


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix pages in which there were elements overflowing the mobile viewport.

#### How should this be manually tested?

Open the [preview]() and check for elements, such as headings, images, iframes, svgs and inline code, overflowing in the documentation pages. [There is a list](https://www.notion.so/vtexhandbook/Aprimorar-navega-o-mobile-136a3b685afc41e2b86123117f1b95d1?pvs=4#ca6cb07a11b548cca01039695b6c22a6) with all the pages in which the overflow was noticed, a couple of them were not fixed because it will be done by changing the documentation file.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
