### PR TITLE
remove Add log in orders from navigation

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -7135,15 +7135,6 @@
                   "origin": "",
                   "endpoint": "/api/oms/pvt/orders/-orderId-/changes",
                   "children": []
-                },
-                {
-                  "name": "Add log in orders",
-                  "slug": "orders-api",
-                  "type": "openapi",
-                  "method": "POST",
-                  "origin": "",
-                  "endpoint": "/api/oms/pvt/orders/-orderId-/interactions",
-                  "children": []
                 }
               ]
             },


### PR DESCRIPTION
remove Add log in orders from navigation

This endpoint used to be hidden from navigation in the old Developer Portal, now it is necessary to remove it, since the team doesn't want to give visibility to this endpoint.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
