### PR TITLE
Feat/fixed sidebar

### DIFF
--- a/src/components/documentation-card/index.tsx
+++ b/src/components/documentation-card/index.tsx
@@ -23,7 +23,7 @@ const DocumentationCard = ({
 }: CardProps) => {
   return (
     <Link href={link} legacyBehavior>
-      <a onClick={onClick}>
+      <a onClick={onClick} style={{ width: '100%' }}>
         <Box sx={cardContainer(containerType)}>
           <Flex sx={titleContainer(containerType)}>
             <Icon size={24} />

--- a/src/components/header/hamburger-menu.tsx
+++ b/src/components/header/hamburger-menu.tsx
@@ -27,11 +27,11 @@ const HamburgerMenu = () => {
     <Header.ActionButton>
       <VtexHamburgerMenu sx={styles.hamburgerContainer}>
         <VtexHamburgerMenu.Menu sx={styles.innerHambugerContainer}>
-          <Box sx={styles.hamburgerSearchContainer}>
-            <SearchInput />
-          </Box>
           <Box sx={styles.menuContainer}>
             <Box sx={styles.cardContainer}>
+              <Box sx={styles.hamburgerSearchContainer}>
+                <SearchInput />
+              </Box>
               <Box
                 sx={styles.documentationContainer}
                 data-cy="dropdown-menu-first-section"
@@ -76,7 +76,7 @@ const HamburgerMenu = () => {
                       aria-label={'Open sidebar'}
                       size="regular"
                       variant="tertiary"
-                      icon={() => <IconCaret direction="right" size={24} />}
+                      icon={() => <IconCaret direction="right" size={32} />}
                       sx={styles.arrowIcon}
                       onClick={() => {
                         setActiveSidebarTab(card.title)

--- a/src/components/header/styles.ts
+++ b/src/components/header/styles.ts
@@ -160,11 +160,13 @@ const innerHambugerContainer: SxStyleProp = {
 const innerCardContainer: SxStyleProp = {
   display: 'flex',
   alignItems: 'center',
+  justifyContent: 'space-between',
 }
 
 const arrowIcon: SxStyleProp = {
   padding: '0',
-  height: '34px',
+  height: '50px',
+  width: '50px',
   color: 'muted.1',
 }
 

--- a/src/components/sidebar-section/index.tsx
+++ b/src/components/sidebar-section/index.tsx
@@ -97,7 +97,7 @@ const SidebarSection = ({
     >
       <Box
         className={sidebarSectionHidden ? 'sidebarHide' : ''}
-        sx={styles.sidebarContainerBox}
+        sx={styles.sidebarContainerBoxHamburger}
       >
         <Flex sx={styles.sidebarContainerTitle}>
           <Button

--- a/src/components/sidebar-section/styles.ts
+++ b/src/components/sidebar-section/styles.ts
@@ -3,9 +3,7 @@ import { SxStyleProp } from '@vtex/brand-ui'
 const sidebarContainer: SxStyleProp = {
   position: 'relative',
   width: 'auto',
-  minHeight: '692px',
-  paddingTop: '34px',
-  paddingBottom: '24px',
+  height: 'inherit',
   borderRight: '1px solid #E7E9EE',
   zIndex: '1',
   left: '0',
@@ -33,6 +31,18 @@ const sidebarContainerHamburger: SxStyleProp = {
 }
 
 const sidebarContainerBox: SxStyleProp = {
+  opacity: '100',
+  transition: 'all 1s ease-out',
+  paddingTop: '34px',
+  paddingBottom: '24px',
+  overflowY: 'auto',
+  height: 'inherit',
+  '::-webkit-scrollbar': {
+    display: 'none',
+  },
+}
+
+const sidebarContainerBoxHamburger: SxStyleProp = {
   opacity: '100',
   transition: 'all 1s ease-out',
 }
@@ -124,6 +134,7 @@ export default {
   sidebarContainer,
   sidebarContainerHamburger,
   sidebarContainerBox,
+  sidebarContainerBoxHamburger,
   sidebarContainerBody,
   sidebarContainerHeader,
   sidebarContainerTitle,

--- a/src/components/sidebar-section/styles.ts
+++ b/src/components/sidebar-section/styles.ts
@@ -32,13 +32,17 @@ const sidebarContainerHamburger: SxStyleProp = {
 
 const sidebarContainerBox: SxStyleProp = {
   opacity: '100',
-  transition: 'all 1s ease-out',
   paddingTop: '34px',
   paddingBottom: '24px',
   overflowY: 'auto',
   height: 'inherit',
-  '::-webkit-scrollbar': {
-    display: 'none',
+  maskImage:
+    'linear-gradient(to top, transparent, black), linear-gradient(to left, transparent 17px, black 17px)',
+  maskSize: '100% 20000px',
+  maskPosition: 'left bottom',
+  transition: 'mask-position 0.3s, -webkit-mask-position 0.3s',
+  ':hover': {
+    maskPosition: 'left top',
   },
 }
 

--- a/src/components/sidebar/styles.ts
+++ b/src/components/sidebar/styles.ts
@@ -7,12 +7,16 @@ const sidebar: SxStyleProp = {
     'none !important',
     'flex !important',
   ],
+  position: 'sticky',
+  left: '0',
+  top: '5rem',
+  flex: '1 0 auto',
+  height: 'calc(100vh - 5rem)',
   width: 'auto',
   minWidth: 'auto',
   transition: 'all 0.3s ease-in-out',
   '.active': {
-    left: '-276px',
-    marginRight: '-120px',
+    marginLeft: '-276px',
     transition: 'all 0.3s ease-in-out',
   },
   '.iconContainerExpanded': {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To implement a fixed sidebar.

#### What problem is this solving?

Users were complaining that in long documentation pages they would have to scroll to the top to be able to use the menu.

#### How should this be manually tested?

Open the preview and check if the sidebar has fixed position. Also check if the hamburger menu is still working as expected.

#### Screenshots or example usage

| Before | After |
|---|---|
|![image](https://user-images.githubusercontent.com/62757720/222187796-bb59431f-651f-4e7b-9774-7173a53fbb9f.png)|![image](https://user-images.githubusercontent.com/62757720/222187650-264df45f-c297-4ded-8d7f-0205b57f31d7.png)|

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
