### PR TITLE
Feat/download spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.2.1-vtex"
+      "version": "1.2.1-vtex-2-g0d8c703"
     }
   },
   "resolutions": {

--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -85,6 +85,7 @@ const APIPage: NextPage<Props> = ({ slug, descriptions }) => {
         schema-style="table"
         schema-description-expanded={true}
         id="the-doc"
+        allow-spec-file-download={true}
       />
     </>
   )


### PR DESCRIPTION
:warning: [Corresponding rapidoc PR](https://github.com/vtexdocs/RapiDoc/pull/26).
:warning: This PR should be merged after merging the Rapidoc branch and updating the version tag.

#### What is the purpose of this pull request?

To add buttons to be able to view and download the open api spec.

#### How should this be manually tested?

Open the preview and check if you are able to view and download the open api spec in the API Reference pages.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/62757720/222742353-0f8ae1cc-c6e0-4374-90ed-fbd2a206b347.png)

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.