### PR TITLE
Fix/responsive design

### DIFF
--- a/src/components/sidebar-section/index.tsx
+++ b/src/components/sidebar-section/index.tsx
@@ -45,6 +45,10 @@ const SidebarSection = ({
   ])
 
   useEffect(() => {
+    if (window.innerWidth < 1920) setSidebarSectionHidden(true)
+  }, [])
+
+  useEffect(() => {
     setFilterStatus(
       methodFilterList.some((methodFilter) => methodFilter.active) ||
         searchValue != ''

--- a/src/styles/documentation-page.ts
+++ b/src/styles/documentation-page.ts
@@ -14,7 +14,7 @@ const innerContainer: SxStyleProp = {
   justifyContent: 'center',
   pt: '64px',
   mx: 'auto',
-  px: ['auto', '5em', '7em', '7em', '7em', '10em', '20em'],
+  px: ['auto', '5em', '7em', '7em', '7em', '7em', '20em'],
 }
 
 const articleBox: SxStyleProp = {
@@ -88,7 +88,7 @@ const bottomContributorsDivider: SxStyleProp = {
 }
 
 const rightContainer: SxStyleProp = {
-  ml: ['68px', '68px', '68px', '68px', '68px', '68px', '200px'],
+  ml: ['38px', '38px', '48px', '48px', '58px', '68px', '200px'],
   display: [
     'none !important',
     'none !important',
@@ -96,7 +96,7 @@ const rightContainer: SxStyleProp = {
     'none !important',
     'initial !important',
   ],
-  minWidth: [0, 0, 0, 0, '189px', '284px', '284px'],
+  minWidth: [0, 0, 0, 0, '139px', '184px', '284px'],
 }
 
 const releaseAction: SxStyleProp = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

- To decrease the width of the contributors component.
- To hide the sidebar by default in smaller (< 1920px) breakpoints.

#### What problem is this solving?

The content container was too small.

#### How should this be manually tested?

Open the preview and check if the sidebar is hidden when you first open the documentation (the sidebar should not close every time the user opens one documentation page, it should only hide for the first time). 
And check if the width of the content container was improved or should be adjusted.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
