### PR TITLE
build(package): update rapidoc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.2.1-vtex-2-g0d8c703"
+      "version": "1.2.2-vtex-3-gebe511c"
     }
   },
   "resolutions": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To update the rapidoc version to fix error that caused a couple of API Reference pages to be empty.

#### What problem is this solving?

The magic block replacer did not check if the string was not undefined.

#### How should this be manually tested?

Open the following API reference pages:
[/docs/api-reference/sku-bindings-api](https://deploy-preview-281--elated-hoover-5c29bf.netlify.app/docs/api-reference/sku-bindings-api)
[/docs/api-reference/message-center-api](https://deploy-preview-281--elated-hoover-5c29bf.netlify.app/docs/api-reference/message-center-api)

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
