### PR TITLE
fix: handle image loading errors

### DIFF
--- a/src/components/markdown-renderer/components.tsx
+++ b/src/components/markdown-renderer/components.tsx
@@ -12,6 +12,7 @@ import CodeBlock from 'components/code-block'
 import styles from './styles.module.css'
 import { Flex } from '@vtex/brand-ui'
 import LightBox from 'components/lightbox'
+import { messages } from 'utils/constants'
 
 type Component = {
   node: object
@@ -91,20 +92,32 @@ export default {
   table: ({ node, ...props }: Component) => <table {...props} />,
   td: ({ node, ...props }: Component) => <td {...props} />,
   img: ({ node, ...props }: Component) => {
+    const [imageHasError, setImageHasError] = useState(false)
+    const [srcHasError, setSrcHasError] = useState(false)
+    const regularImg = (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={props.src}
+        alt={props.alt}
+        onError={() => setSrcHasError(true)}
+      />
+    )
+    const errorMessage = (
+      <blockquote
+        className={`${styles.blockquote} ${styles.blockquoteWarning}`}
+      >
+        {messages['error_loading_image']} {props.src}
+      </blockquote>
+    )
+
     let data: { base64: string; img: object } = { base64: '', img: {} }
     try {
       data = JSON.parse(props.alt)
     } catch (error) {
       console.log(`Error parsing`, error)
-      return (
-        <>
-          <p>
-            <strong> Não pude carregar Imagem {props.src}</strong>
-          </p>
-        </>
-      )
+      return errorMessage
     }
-    return (
+    return !imageHasError ? (
       <LightBox>
         <Image
           className={styles.img}
@@ -117,9 +130,14 @@ export default {
             objectFit: 'contain',
             height: 'auto',
           }}
+          onError={() => setImageHasError(true)}
           {...data?.img}
         />
       </LightBox>
+    ) : !srcHasError ? (
+      <LightBox>{regularImg}</LightBox>
+    ) : (
+      errorMessage
     )
   },
   blockquote: ({ ...props }: Component) => {

--- a/src/messages/language.json
+++ b/src/messages/language.json
@@ -83,5 +83,6 @@
   "app_development_page_other_resources_github.description": "VTEX IO open-source apps and documentation are fully stored in the VTEX Apps Organization on GitHub.",
   "app_development_page_other_resources_help_center.description": "The Help Center contains beginner tutorials, reference guides and troubleshooting articles about the VTEX Admin panel.",
   "app_development_page_other_resources_support.description": "All clients have access to the services provided by our Technical Support team. These specialists are extensively prepared to give you the best experience possible when solving your tickets. To contact them, you need to open a ticket to VTEX support.",
-  "relese-note-days-elapsed": "days ago"
+  "relese-note-days-elapsed": "days ago",
+  "error_loading_image": "An error occurred while trying to load the image."
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To handle errors when an image is not loaded correctly. If the NextJs image component is not loaded correctly, a regular img element will be used, if the error persists, an error message will appear.

#### What problem is this solving?

The alternative text shown when the image was not loaded was not helpful.

#### How should this be manually tested?

Open the [preview](https://deploy-preview-283--elated-hoover-5c29bf.netlify.app/) and check if the images are rendered correctly or are replaced by the error message.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/62757720/225366287-e7a42b76-e182-4347-9b7b-180778044e4a.png)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
