### PR TITLE
fix(sidebar): check the parent to expand the correct endpoint

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, useContext } from 'react'
 import { Flex, Text, Box } from '@vtex/brand-ui'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { flattenJSON, getKeyByValue, getParents } from 'utils/navigation-utils'
+import { flattenJSON, getKeysByValue, getParents } from 'utils/navigation-utils'
 
 import styles from './styles'
 import type { SidebarSectionProps } from 'components/sidebar-section'
@@ -46,22 +46,27 @@ const Sidebar = ({
   const router = useRouter()
   const flattenedSidebar = flattenJSON(sidebarDataMaster)
   let activeSlug = ''
-  let keyPath = ''
+  let keyPath: string[] = []
   const querySlug = router.query.slug
   if (querySlug && router.pathname === '/docs/api-reference/[slug]') {
     activeSlug = router.asPath.replace('/docs/api-reference/', '')
     const docPath = activeSlug.split('/')
     const endpoint = '/' + docPath.splice(1, docPath.length).join('/')
-    keyPath = getKeyByValue(flattenedSidebar, endpoint)
-      ? getKeyByValue(flattenedSidebar, endpoint)!
-      : ''
+    keyPath = getKeysByValue(flattenedSidebar, endpoint)
     if (endpoint == '/') {
       activeSlug = docPath[0].split('#')[0]
     }
     parentsArray.push(activeSlug)
-    if (keyPath.length > 1) {
-      getParents(keyPath, 'slug', flattenedSidebar, parentsArray)
-    }
+    keyPath.forEach((key: string) => {
+      if (key.length > 0)
+        getParents(
+          key,
+          'slug',
+          flattenedSidebar,
+          parentsArray,
+          activeSlug.split('#')[0]
+        )
+    })
   } else {
     activeSlug = parentsArray[parentsArray.length - 1]
   }
@@ -77,7 +82,7 @@ const Sidebar = ({
     return () => {
       clearTimeout(timer)
     }
-  }, [activeSidebarElement, router, keyPath])
+  }, [activeSidebarElement, router])
 
   const SideBarIcon = (iconElement: DocDataElement | UpdatesDataElement) => {
     const [iconTooltip, setIconTooltip] = useState(false)

--- a/src/utils/navigation-utils.ts
+++ b/src/utils/navigation-utils.ts
@@ -22,11 +22,19 @@ export const getKeyByValue = (
   return Object.keys(object).find((key) => object[key] === value)
 }
 
+export const getKeysByValue = (
+  object: { [x: string]: string },
+  value: string
+) => {
+  return Object.keys(object).filter((key) => object[key] === value)
+}
+
 export const getParents = (
   path: string,
   data: string,
   flattenedSidebar: { [x: string]: string },
-  parentsArray: string[]
+  parentsArray: string[],
+  parent?: string
 ) => {
   const pathParts = path?.split('children')
   pathParts?.splice(-1)
@@ -34,7 +42,10 @@ export const getParents = (
   pathParts?.map((el) => {
     el = prev + el
     prev = el + 'children'
-    parentsArray.push(flattenedSidebar[`${el}${data}`])
+
+    if (!parent || flattenedSidebar[`${el}${data}`].includes(parent)) {
+      parentsArray.push(flattenedSidebar[`${el}${data}`])
+    }
   })
   return parentsArray
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix problem in which the wrong sidebar endpoint was expanded because the endpoint was the same to the one selected.

#### What problem is this solving?

The sidebar did show the open documentation correctly.

#### How should this be manually tested?

Open a endpoint that is not unique and check if the sidebar is correct. Example:
Payment Provider Protocol > Configuration Flow > Create Authorization Token (Post) (endpoint is /authorization/token)
Antifraud Provider > OAuth Flow -> 1. Retrieve Token (endpoint also is /authorization/token)

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
