### PR TITLE
build: update rapidoc version

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
       "path": "./node_modules/cz-conventional-changelog"
     },
     "rapidoc": {
-      "version": "1.2.3-vtex"
+      "version": "1.2.3-vtex-3-gad0d448"
     }
   },
   "resolutions": {


### PR DESCRIPTION
[Corresponding RapiDoc PR](https://github.com/vtexdocs/RapiDoc/pull/29)

#### What is the purpose of this pull request?

To update the rapidoc version to show the complete endpoint URL in the top of the API Reference page.

#### What problem is this solving?

On some documentations part of the path that was common between for more than one endpoint was contained only in the server URL, so the endpoint path was incomplete.

#### How should this be manually tested?

Open any API Reference page and check if the URL contained in the component in the start of the page is complete.

#### Screenshots or example usage

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/62757720/228538666-319a06bb-ae2f-4d8d-ad25-649ba50bb330.png) | ![image](https://user-images.githubusercontent.com/62757720/228538717-82da5312-0833-47c0-99d3-2f6e2c79c8c8.png) |

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
