### PR TITLE
fix(api-reference): retrieve missing title and description from reference pages

### DIFF
--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -28,6 +28,18 @@ function capitalize(content: string) {
   return content.replace(/^./, content[0].toUpperCase())
 }
 
+function getDescription(description: string) {
+  return (
+    description
+      .split(/\r?\n/)
+      .map((line: string) => line.trim())
+      .find(
+        (line: string) =>
+          line && line[0].toLowerCase() !== line[0].toUpperCase()
+      ) || ''
+  )
+}
+
 const referencePaths = await getReferencePaths()
 const slugs = Object.keys(await getReferencePaths())
 
@@ -46,7 +58,8 @@ const APIPage: NextPage<Props> = ({ slug, endpoints }) => {
   const httpMethod = getMethod() as MethodType | ''
 
   useEffect(() => {
-    setEndpointPath(`#${router.asPath.split('#')[1]}`)
+    const path = router.asPath.split('#')[1]
+    setEndpointPath(path ? `#${router.asPath.split('#')[1]}` : slug)
   }, [router.asPath])
 
   useEffect(() => {
@@ -136,13 +149,18 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     )
     const doc = await response.json()
     const endpointFile = new Oas(doc)
-    const allPaths = endpointFile.getDefinition().paths
+    const { info, paths } = endpointFile.getDefinition()
     const endpoints: {
       [key: string]: Endpoint
     } = {}
 
-    if (allPaths) {
-      Object.entries(allPaths).forEach(([key, value]) => {
+    endpoints[slug as string] = {
+      title: info.title,
+      description: getDescription(info.description || ''),
+    }
+
+    if (paths) {
+      Object.entries(paths).forEach(([key, value]) => {
         if (value) {
           Object.entries(value).forEach(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -154,15 +172,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
               ) {
                 endpoints[`#${endpointKey}-${key.replaceAll(/{|}/g, '-')}`] = {
                   title: endpointValue.summary || '',
-                  description:
-                    endpointValue.description
-                      .split(/\r?\n/)
-                      .map((line: string) => line.trim())
-                      .find(
-                        (line: string) =>
-                          line &&
-                          line[0].toLowerCase() !== line[0].toUpperCase()
-                      ) || '',
+                  description: getDescription(endpointValue.description),
                 }
               }
             }

--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -140,8 +140,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     const endpoints: {
       [key: string]: Endpoint
     } = {}
-    const isMethod = (key: string) =>
-      ['get', 'post', 'delete', 'put'].includes(key)
 
     if (allPaths) {
       Object.entries(allPaths).forEach(([key, value]) => {
@@ -150,7 +148,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             ([endpointKey, endpointValue]: any) => {
               if (
-                isMethod(endpointKey) &&
+                isMethodType(endpointKey.toUpperCase()) &&
                 endpointValue &&
                 endpointValue.description
               ) {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Retrieve the title and description of patch-type endpoints and OpenAPI overviews
code refactoring

#### What problem is this solving?
Before, we only matched if an endpoint have type: 'get', 'post', 'delete', or 'put' but not 'patch'. I will refactor the code to get the type from constants to be easier to update after.
![image](https://user-images.githubusercontent.com/42784961/232541081-91e6ea18-4e6e-4d83-a2e1-6561d801c01c.png)

#### How should this be manually tested?

Check different endpoint types in the preview if the meta "doctitle:" has content.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
