### PR TITLE
fix: nextjs shouldn't optimize image if it is a gif

### DIFF
--- a/src/components/markdown-renderer/components.tsx
+++ b/src/components/markdown-renderer/components.tsx
@@ -183,6 +183,7 @@ export default {
             height: 'auto',
           }}
           onError={() => setImageHasError(true)}
+          unoptimized={props.src.includes('.gif')}
           {...data?.img}
         />
       </LightBox>


### PR DESCRIPTION
#### What is the purpose of this pull request?

To show gifs correctly.

#### What problem is this solving?

NextJs image optimization doesn't work with gifs, causing gifs to appear as static images.

#### How should this be manually tested?

Open the [preview](https://deploy-preview-355--elated-hoover-5c29bf.netlify.app/) and check if gifs are working as expected. [Example](https://deploy-preview-355--elated-hoover-5c29bf.netlify.app/docs/guides/checkout-overview).

#### Screenshots or example usage

Mostrando como gif está aparecendo atualmente no portal e como deveria estar:

https://user-images.githubusercontent.com/62757720/235165991-f4934bde-6ae8-45f8-9b9c-5e013e59ab57.mp4

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
