### PR TITLE
Update navigation.json

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -12472,20 +12472,6 @@
                   "origin": "",
                   "type": "markdown",
                   "children": []
-                },
-                {
-                  "name": "Migrating Google Tag Manager app from major 2.x to major 3.x",
-                  "slug": "vtex-io-documentation-migrating-google-tag-manager-app",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "Sending custom events to Google Tag Manager",
-                  "slug": "vtex-io-documentation-sending-custom-events-to-google-tag-manager",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
                 }
               ]
             },


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR aims to delete do doc mentions from the sidebar [Migrating GTM](https://developers.vtex.com/docs/guides/vtex-io-documentation-migrating-google-tag-manager-app) and [Sending Custom Events to GTM](https://developers.vtex.com/docs/guides/vtex-io-documentation-sending-custom-events-to-google-tag-manager). With the [new version of the GTM app](https://developers.vtex.com/docs/guides/vtex-io-documentation-installing-google-tag-manager), these two documentation are not longer valid.

Resources:
https://github.com/vtexdocs/dev-portal-content/pull/414

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
