### PR TITLE
Chore: fix Order Form redirect 

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,12 @@ included_files = ["node_modules/sharp/**/*", "./github.pem"]
 
 [[redirects]]
 force = true
+from = "/404/docs/recipes/store-management/enabling-order-form-optimization"
+status = 308
+to = "/docs/guides/vtex-io-documentation-enabling-order-form-optimization"
+
+[[redirects]]
+force = true
 from = "/docs/recipes/store-management/enabling-order-form-optimization"
 status = 308
 to = "/docs/guides/vtex-io-documentation-enabling-order-form-optimization"


### PR DESCRIPTION
#### What is the purpose of this pull request?

The goal is to redirect [this doc](https://vtex.io/docs/recipes/store-management/enabling-order-form-optimization) to its correct path: https://developers.vtex.com/docs/guides/vtex-io-documentation-enabling-order-form-optimization. However, currently, the documentation page is rendering incorrectly with the path "/404/docs/recipes/store-management/enabling-order-form-optimization". This pull request aims to fix the redirect so the documentation page is correctly redirected to its intended path.

Reference: #379 
🔗 [Preview](https://deploy-preview-380--elated-hoover-5c29bf.netlify.app/404/docs/recipes/store-management/enabling-order-form-optimization)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
