### PR TITLE
perf(reference): openapi filter and add new routes for reference pages

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -22,6 +22,7 @@ interface Props {
   isEditor?: boolean
   sectionSelected?: DocumentationTitle | UpdatesTitle | ''
   parentsArray?: string[]
+  slugAPI?: string
 }
 
 // const tracker = new OpenReplay({
@@ -37,6 +38,7 @@ export default function Layout({
   isEditor,
   sectionSelected,
   parentsArray,
+  slugAPI,
 }: Props) {
   const { initTracker, startTracking } = useContext(TrackerContext)
   useEffect(() => {
@@ -81,7 +83,9 @@ export default function Layout({
       >
         <Header isEditor={isEditor ? true : false} />
         <Flex sx={styles.container}>
-          {!hideSidebar && <Sidebar parentsArray={parentsArray} />}
+          {!hideSidebar && (
+            <Sidebar slugAPI={slugAPI} parentsArray={parentsArray} />
+          )}
           <Box sx={styles.mainContainer}>{children}</Box>
         </Flex>
       </SidebarContextProvider>

--- a/src/components/sidebar-elements/index.tsx
+++ b/src/components/sidebar-elements/index.tsx
@@ -106,7 +106,7 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
     children,
   }: SidebarElement) => {
     const isExpandable = children.length > 0
-    const pathSuffix = method ? `#${method.toLowerCase()}-${endpoint}` : ''
+    const pathSuffix = method ? `/${method.toLowerCase()}-${endpoint}` : ''
     const activeItem = method ? `${slug}${pathSuffix}` : slug
     return (
       <Box sx={styles.elementContainer}>

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -26,9 +26,10 @@ import useNavigation from 'utils/hooks/useNavigation'
 
 interface SideBarSectionState {
   parentsArray?: string[]
+  slugAPI?: string
 }
 
-const Sidebar = ({ parentsArray = [] }: SideBarSectionState) => {
+const Sidebar = ({ parentsArray = [], slugAPI = '' }: SideBarSectionState) => {
   const [expandDelayStatus, setExpandDelayStatus] = useState(true)
 
   const {
@@ -48,25 +49,23 @@ const Sidebar = ({ parentsArray = [] }: SideBarSectionState) => {
   useEffect(() => {
     if (!isEditorPreview) setSidebarDataMaster(sidebarNavigation)
   }, [sidebarNavigation])
-
   const router = useRouter()
   const flattenedSidebar = flattenJSON(sidebarNavigation)
   let activeSlug = ''
   const querySlug = router.query.slug
   if (querySlug && router.pathname === '/docs/api-reference/[...slug]') {
-    activeSlug = router.asPath.replace('/docs/api-reference/', '')
+    activeSlug = router.asPath
+      .replace('/docs/api-reference/', '')
+      .replace('#', '/')
     const docPath = activeSlug.split('/')
-    const apiSlug = docPath[0].split('#')[0]
-    const endpoint = '/' + docPath.splice(1, docPath.length).join('/')
+    const endpoint = '/' + docPath.slice(2, docPath.length).join('/')
     let keyPath
     if (endpoint == '/') {
-      activeSlug = apiSlug
-      keyPath = getKeyByEndpoint(flattenedSidebar, '', apiSlug)
+      activeSlug = slugAPI
+      keyPath = getKeyByEndpoint(flattenedSidebar, '', slugAPI)
     } else {
-      const method = docPath[0].includes('#')
-        ? docPath[0].split('#')[1].split('-')[0]
-        : docPath[1]
-      keyPath = getKeyByEndpoint(flattenedSidebar, endpoint, apiSlug, method)
+      const method = docPath[1]?.split('-')[0]
+      keyPath = getKeyByEndpoint(flattenedSidebar, endpoint, slugAPI, method)
     }
     parentsArray.push(activeSlug)
     if (keyPath) {

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -63,7 +63,9 @@ const Sidebar = ({ parentsArray = [] }: SideBarSectionState) => {
       activeSlug = apiSlug
       keyPath = getKeyByEndpoint(flattenedSidebar, '', apiSlug)
     } else {
-      const method = docPath[0].split('#')[1].split('-')[0]
+      const method = docPath[0].includes('#')
+        ? docPath[0].split('#')[1].split('-')[0]
+        : docPath[1]
       keyPath = getKeyByEndpoint(flattenedSidebar, endpoint, apiSlug, method)
     }
     parentsArray.push(activeSlug)

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -53,7 +53,7 @@ const Sidebar = ({ parentsArray = [] }: SideBarSectionState) => {
   const flattenedSidebar = flattenJSON(sidebarNavigation)
   let activeSlug = ''
   const querySlug = router.query.slug
-  if (querySlug && router.pathname === '/docs/api-reference/[slug]') {
+  if (querySlug && router.pathname === '/docs/api-reference/[...slug]') {
     activeSlug = router.asPath.replace('/docs/api-reference/', '')
     const docPath = activeSlug.split('/')
     const apiSlug = docPath[0].split('#')[0]

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -34,6 +34,7 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }: Props) {
             isEditor={Component.isEditor}
             sectionSelected={pageProps.sectionSelected}
             parentsArray={pageProps.parentsArray}
+            slugAPI={pageProps.slugAPI}
           >
             <Component {...pageProps} />
           </Layout>

--- a/src/pages/api/openapi/[slug].tsx
+++ b/src/pages/api/openapi/[slug].tsx
@@ -9,7 +9,7 @@ export const config = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
   const { slug } = req.query
-  const filteredOpenAPI = filterOpenAPI(slug)
+  const filteredOpenAPI = await filterOpenAPI(slug)
 
   if (filteredOpenAPI) {
     res

--- a/src/pages/api/openapi/[slug].tsx
+++ b/src/pages/api/openapi/[slug].tsx
@@ -1,89 +1,23 @@
+import filterOpenAPI from 'utils/filterOpenAPI'
+
 export const config = {
   api: {
     bodyParser: false,
   },
 }
 
-const referencePaths = objectFlip({
-  'VTEX - Antifraud Provider API': 'antifraud-provider-protocol',
-  'VTEX - CMS API': 'cms-api',
-  'VTEX - Catalog API Seller Portal': 'catalog-api-seller-portal',
-  'VTEX - Catalog API': 'catalog-api',
-  'VTEX - Checkout API': 'checkout-api',
-  'VTEX - Customer Credit API': 'customer-credit-api',
-  'VTEX - GiftCard Hub API': 'giftcard-hub-api',
-  'VTEX - Giftcard API': 'giftcard-api',
-  'VTEX - Giftcard Provider Protocol': 'giftcard-provider-protocol',
-  'VTEX - Headless CMS API': 'headless-cms-api',
-  'VTEX - Intelligent Search API': 'intelligent-search-api',
-  'VTEX - License Manager API': 'license-manager-api',
-  'VTEX - Logistics API': 'logistics-api',
-  'VTEX - Marketplace APIs': 'marketplace-apis',
-  'VTEX - Marketplace APIs - Suggestions': 'marketplace-apis-suggestions',
-  'VTEX - Marketplace APIs - Sent Offers': 'marketplace-apis-offer-management',
-  'VTEX - Marketplace Protocol - External Marketplace Mapper':
-    'marketplace-protocol-external-marketplace-mapper',
-  'VTEX - Marketplace Protocol - External Marketplace Orders':
-    'marketplace-protocol-external-marketplace-orders',
-  'VTEX - Marketplace Protocol - External Seller Fulfillment':
-    'marketplace-protocol-external-seller-fulfillment',
-  'VTEX - Marketplace Protocol - External Seller Marketplace':
-    'marketplace-protocol',
-  'VTEX - Master Data API - v2': 'master-data-api-v2',
-  'VTEX - MasterData API - v10.2': 'masterdata-api',
-  'VTEX - Message Center API': 'message-center-api',
-  'VTEX - Orders API (PII version)': 'orders-api-pii-version',
-  'VTEX - Orders API': 'orders-api',
-  'VTEX - Payment Provider Protocol': 'payment-provider-protocol',
-  'VTEX - Payments Gateway API': 'payments-gateway-api',
-  'VTEX - Policies System API': 'policies-system-api',
-  'VTEX - Price Simulations': 'price-simulations',
-  'VTEX - Pricing API': 'pricing-api',
-  'VTEX - Pricing Hub': 'pricing-hub',
-  'VTEX - Profile System': 'profile-system',
-  'VTEX - Promotions & Taxes API': 'promotions-and-taxes-api',
-  'VTEX - Recurrence (v1 - deprecated)': 'recurrence-v1-deprecated',
-  'VTEX - Reviews and Ratings API': 'reviews-and-ratings-api',
-  'VTEX - SKU Bindings API': 'sku-bindings-api',
-  'VTEX - Search API': 'search-api',
-  'VTEX - Session Manager API': 'session-manager-api',
-  'VTEX - Subscriptions API (v2)': 'subscriptions-api-v2',
-  'VTEX - Subscriptions API (v3)': 'subscriptions-api-v3',
-  'VTEX - Tracking': 'tracking',
-  'VTEX - VTEX Do API': 'vtex-do-api',
-  'VTEX - VTEX ID API': 'vtex-id-api',
-  'VTEX - VTEX Shipping Network API': 'vtex-shipping-network-api',
-  'VTEX - Promotions & Taxes API - v2': 'promotions-and-taxes-api-v2',
-  'VTEX - Intelligent Search Events API - Headless':
-    'intelligent-search-events-api-headless',
-})
-
-function objectFlip(obj: { [x: string]: string }) {
-  return Object.keys(obj).reduce((ret, key) => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    ret[obj[key]] = key
-    return ret
-  }, {})
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
   const { slug } = req.query
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const path = referencePaths[slug] || ''
-  if (path) {
-    const response = await fetch(
-      `https://raw.githubusercontent.com/vtex/openapi-schemas/master/${path}.json`
-    )
-    const body = await response.text()
+  const filteredOpenAPI = filterOpenAPI(slug)
+
+  if (filteredOpenAPI) {
     res
       .setHeader(
         'Cache-Control',
         'public, s-maxage=300, stale-while-revalidate=250'
       )
-      .send(body)
+      .send(filteredOpenAPI)
   } else {
     res.status(404)
   }

--- a/src/pages/docs/api-reference/[...slug].tsx
+++ b/src/pages/docs/api-reference/[...slug].tsx
@@ -14,6 +14,7 @@ import { MethodType, isMethodType } from 'utils/typings/unionTypes'
 import '../../../../RapiDoc/src/rapidoc.js'
 import { flattenWithChildren } from 'utils/navigation-utils'
 import { getLogger } from 'utils/logging/log-util'
+import getReferenceEndpoints from 'utils/getReferenceEndpoints'
 
 interface Endpoint {
   title: string
@@ -65,6 +66,9 @@ function getDescription(description: string) {
 
 const referencePaths = await getReferencePaths()
 const slugs = Object.keys(await getReferencePaths())
+const referenceEndpoints = (await getReferenceEndpoints({
+  sitemap: false,
+})) as string[]
 
 const APIPage: NextPage<Props> = ({
   slug,
@@ -181,8 +185,8 @@ const APIPage: NextPage<Props> = ({
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = slugs.map((slug) => ({
-    params: { slug },
+  const paths = referenceEndpoints.map((slug) => ({
+    params: { slug: [slug] },
   }))
   return {
     paths,
@@ -191,7 +195,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 }
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const slug = params?.slug || ''
+  const slug = params?.slug ? params?.slug[0] : ''
   const url = referencePaths[slug as string]
   const sectionSelected = 'API Reference'
   const sidebarfallback = await getNavigation()

--- a/src/pages/docs/api-reference/[...slug].tsx
+++ b/src/pages/docs/api-reference/[...slug].tsx
@@ -110,11 +110,6 @@ const APIPage: NextPage<Props> = ({
   const endpointPath = router.asPath.split(slugAPI)[1].substring(1) || slugAPI
 
   useEffect(() => {
-    if (slugAPI !== slug && rapidoc.current)
-      rapidoc.current.scrollToPath(slug.slice(slug.indexOf('/') + 1))
-  }, [slug])
-
-  useEffect(() => {
     const scrollDoc = () => {
       if (rapidoc.current) {
         if (slugAPI === slug)

--- a/src/pages/docs/api-reference/[...slug].tsx
+++ b/src/pages/docs/api-reference/[...slug].tsx
@@ -96,7 +96,6 @@ const APIPage: NextPage<Props> = ({
     return method && isMethodType(method) ? method : ''
   }
   const httpMethod: MethodType | '' = getMethod()
-  const hash = router.asPath.split('#')[1]
   const pag: Pagination = {
     previousDoc: {
       name: null,
@@ -108,7 +107,7 @@ const APIPage: NextPage<Props> = ({
     },
   }
   const [endpointPagination, setEndpointPagination] = useState(pag)
-  const endpointPath = hash ? `#${hash}` : slugAPI
+  const endpointPath = router.asPath.split(slugAPI)[1].substring(1) || slugAPI
 
   useEffect(() => {
     if (slugAPI !== slug && rapidoc.current)
@@ -249,7 +248,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
                 endpointValue &&
                 endpointValue.description
               ) {
-                endpoints[`#${endpointKey}-${key.replaceAll(/{|}/g, '-')}`] = {
+                endpoints[`${endpointKey}-${key.replaceAll(/{|}/g, '-')}`] = {
                   title: endpointValue.summary || '',
                   description: getDescription(endpointValue.description),
                 }

--- a/src/pages/docs/api-reference/[...slug].tsx
+++ b/src/pages/docs/api-reference/[...slug].tsx
@@ -163,6 +163,7 @@ const APIPage: NextPage<Props> = ({
           postman-url={`/api/postman/${slug}`}
           spec-url={`/api/openapi/${slugAPI}`}
           spec={doc}
+          route-prefix={slug === slugAPI ? '#' : `${slugAPI}/`}
           layout="column"
           render-style="focused"
           show-header="false"

--- a/src/pages/server-sitemap.xml/index.ts
+++ b/src/pages/server-sitemap.xml/index.ts
@@ -1,41 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getServerSideSitemap } from 'next-sitemap'
-import getNavigation from 'utils/getNavigation'
-
-const DOMAIN_URL = 'https://developers.vtex.com/docs/api-reference'
-
-function getEndpoint(element: any) {
-  let urls: any = []
-  if (element.children) {
-    const children = element.children.flatMap((e: any) => {
-      return getEndpoint(e)
-    })
-    urls = children
-  }
-
-  if (element.type === 'openapi') {
-    const url: any = {}
-    const pathSuffix = element.method
-      ? `#${element.method.toLowerCase()}-${element.endpoint
-          .replaceAll('{', '-')
-          .replaceAll('}', '-')}`
-      : ''
-    url.loc = `${DOMAIN_URL}/${element.slug}/${pathSuffix}`
-    url.lastmod = new Date().toISOString()
-    urls.push(url)
-  }
-  return urls
-}
+import getReferenceEndpoints, { SitemapUrl } from 'utils/getReferenceEndpoints'
 
 export async function getServerSideProps(ctx: any) {
-  const documents = await getNavigation()
-  const referenceCategories = documents.find(
-    (document: any) => document.documentation === 'API Reference'
-  )
-  let references: any[] = []
-  referenceCategories.categories.forEach((category: any) => {
-    references = references.concat(getEndpoint(category))
-  })
+  const references = (await getReferenceEndpoints({
+    sitemap: true,
+  })) as SitemapUrl[]
 
   return await getServerSideSitemap(ctx, references)
 }

--- a/src/tests/cypress/integration/api-reference.cy.js
+++ b/src/tests/cypress/integration/api-reference.cy.js
@@ -52,11 +52,13 @@ describe('API reference documentation page', () => {
       cy.get('.css-1450tp')
         .eq(idx + 1)
         .find('button')
+        .scrollIntoView()
         .click({ force: true })
 
       cy.get('.css-1450tp')
         .eq(idx + 2)
         .find('a')
+        .scrollIntoView()
         .click({ force: true })
     })
 

--- a/src/tests/cypress/integration/api-reference.cy.js
+++ b/src/tests/cypress/integration/api-reference.cy.js
@@ -2,6 +2,13 @@
 
 import { writeLog } from '../support/functions'
 
+function isButtonActive(index) {
+  cy.get('.css-1450tp')
+    .eq(index)
+    .find('button')
+    .should('have.css', 'color', 'rgb(215, 29, 85)')
+}
+
 describe('API reference documentation page', () => {
   before(() => {
     cy.task('setUrl', '/docs/api-reference')
@@ -24,20 +31,11 @@ describe('API reference documentation page', () => {
     }
   })
 
-  it('Check if the sidebar collapse button works', () => {
+  it('Check if a random guide page, chosen using the sidebar, loads', () => {
     cy.get('.toggleIcon')
       .scrollIntoView({ offset: { top: -100 } })
       .should('not.be.visible')
-      .click()
-    cy.get('[data-cy="sidebar-section"]').should('not.be.visible')
-    cy.get('.toggleIcon')
-      .scrollIntoView({ offset: { top: -100 } })
-      .should('be.visible')
-      .click()
-    cy.get('[data-cy="sidebar-section"]').should('be.visible')
-  })
 
-  it('Check if a random guide page, chosen using the sidebar, loads', () => {
     cy.get('.css-1450tp')
       .anyWithIndex()
       .then(([category, index]) => {
@@ -46,19 +44,30 @@ describe('API reference documentation page', () => {
       })
       .scrollIntoView()
       .find('button')
-      .click({ force: true })
+      .should('be.visible')
+      .then(($btn) => {
+        $btn.trigger('click')
+      })
 
     cy.get('@idx').then((idx) => {
+      isButtonActive(idx)
+
       cy.get('.css-1450tp')
         .eq(idx + 1)
         .find('button')
         .scrollIntoView()
-        .click({ force: true })
+        .should('be.visible')
+        .then(($btn) => {
+          $btn.trigger('click')
+        })
+
+      isButtonActive(idx + 1)
 
       cy.get('.css-1450tp')
         .eq(idx + 2)
         .find('a')
         .scrollIntoView()
+        .should('be.visible')
         .click({ force: true })
     })
 

--- a/src/utils/filterOpenAPI.ts
+++ b/src/utils/filterOpenAPI.ts
@@ -1,0 +1,96 @@
+function objectFlip(obj: { [x: string]: string }) {
+  return Object.keys(obj).reduce((ret, key) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    ret[obj[key]] = key
+    return ret
+  }, {})
+}
+
+const referencePaths = objectFlip({
+  'VTEX - Antifraud Provider API': 'antifraud-provider-protocol',
+  'VTEX - CMS API': 'cms-api',
+  'VTEX - Catalog API Seller Portal': 'catalog-api-seller-portal',
+  'VTEX - Catalog API': 'catalog-api',
+  'VTEX - Checkout API': 'checkout-api',
+  'VTEX - Customer Credit API': 'customer-credit-api',
+  'VTEX - GiftCard Hub API': 'giftcard-hub-api',
+  'VTEX - Giftcard API': 'giftcard-api',
+  'VTEX - Giftcard Provider Protocol': 'giftcard-provider-protocol',
+  'VTEX - Headless CMS API': 'headless-cms-api',
+  'VTEX - Intelligent Search API': 'intelligent-search-api',
+  'VTEX - License Manager API': 'license-manager-api',
+  'VTEX - Logistics API': 'logistics-api',
+  'VTEX - Marketplace APIs': 'marketplace-apis',
+  'VTEX - Marketplace APIs - Suggestions': 'marketplace-apis-suggestions',
+  'VTEX - Marketplace APIs - Sent Offers': 'marketplace-apis-offer-management',
+  'VTEX - Marketplace Protocol - External Marketplace Mapper':
+    'marketplace-protocol-external-marketplace-mapper',
+  'VTEX - Marketplace Protocol - External Marketplace Orders':
+    'marketplace-protocol-external-marketplace-orders',
+  'VTEX - Marketplace Protocol - External Seller Fulfillment':
+    'marketplace-protocol-external-seller-fulfillment',
+  'VTEX - Marketplace Protocol - External Seller Marketplace':
+    'marketplace-protocol',
+  'VTEX - Master Data API - v2': 'master-data-api-v2',
+  'VTEX - MasterData API - v10.2': 'masterdata-api',
+  'VTEX - Message Center API': 'message-center-api',
+  'VTEX - Orders API (PII version)': 'orders-api-pii-version',
+  'VTEX - Orders API': 'orders-api',
+  'VTEX - Payment Provider Protocol': 'payment-provider-protocol',
+  'VTEX - Payments Gateway API': 'payments-gateway-api',
+  'VTEX - Policies System API': 'policies-system-api',
+  'VTEX - Price Simulations': 'price-simulations',
+  'VTEX - Pricing API': 'pricing-api',
+  'VTEX - Pricing Hub': 'pricing-hub',
+  'VTEX - Profile System': 'profile-system',
+  'VTEX - Promotions & Taxes API': 'promotions-and-taxes-api',
+  'VTEX - Recurrence (v1 - deprecated)': 'recurrence-v1-deprecated',
+  'VTEX - Reviews and Ratings API': 'reviews-and-ratings-api',
+  'VTEX - SKU Bindings API': 'sku-bindings-api',
+  'VTEX - Search API': 'search-api',
+  'VTEX - Session Manager API': 'session-manager-api',
+  'VTEX - Subscriptions API (v2)': 'subscriptions-api-v2',
+  'VTEX - Subscriptions API (v3)': 'subscriptions-api-v3',
+  'VTEX - Tracking': 'tracking',
+  'VTEX - VTEX Do API': 'vtex-do-api',
+  'VTEX - VTEX ID API': 'vtex-id-api',
+  'VTEX - VTEX Shipping Network API': 'vtex-shipping-network-api',
+  'VTEX - Promotions & Taxes API - v2': 'promotions-and-taxes-api-v2',
+})
+
+export default async function filterOpenAPI(slug: string) {
+  const slugArray = slug.split('/')
+  const slugAPI = slugArray[0]
+  const slugMethod = slugArray[1] ? slugArray[1].slice(0, -1) : ''
+  const slugEndpoint = slugArray[2] ? '/' + slugArray.slice(2).join('/') : ''
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const path = referencePaths[slugAPI] || ''
+
+  if (path) {
+    const response = await fetch(
+      `https://raw.githubusercontent.com/vtex/openapi-schemas/master/${path}.json`
+    )
+    const body = await response.text()
+    const openAPI = JSON.parse(body)
+    const filteredOpenAPI = openAPI
+
+    if (slugMethod && slugEndpoint) {
+      const regex = /\/-([^{}-]+)-/g
+      const fixedEndpoint = slugEndpoint.replace(regex, (_match, param) => {
+        return '/{' + param + '}'
+      })
+
+      filteredOpenAPI.paths = {
+        [slugEndpoint]: {
+          [slugMethod]: openAPI.paths[fixedEndpoint][slugMethod],
+        },
+      }
+    }
+
+    return filteredOpenAPI
+  }
+
+  return ''
+}

--- a/src/utils/getReferenceEndpoints.ts
+++ b/src/utils/getReferenceEndpoints.ts
@@ -1,0 +1,72 @@
+import getNavigation from './getNavigation'
+import { DocumentationTitle, UpdatesTitle } from './typings/unionTypes'
+
+const DOMAIN_URL = 'https://developers.vtex.com/docs/api-reference'
+
+type NavigationElement = {
+  slug: string
+  type: string
+  method?: string
+  endpoint?: string
+  children?: NavigationElement[]
+}
+
+type NavigationCategory = {
+  documentation: DocumentationTitle | UpdatesTitle
+  categories: NavigationElement[]
+}
+
+export type SitemapUrl = {
+  loc: string
+  lastmod: string
+}
+
+function getEndpoint(element: NavigationElement, sitemap: boolean) {
+  let urls: (SitemapUrl | string)[] = []
+  if (element.children) {
+    const children = element.children.flatMap((child: NavigationElement) => {
+      return getEndpoint(child, sitemap)
+    })
+    urls = children
+  }
+
+  if (element.type === 'openapi') {
+    const pathSuffix =
+      element.method && element.endpoint
+        ? `${element.method.toLowerCase()}${element.endpoint
+            .replaceAll('{', '-')
+            .replaceAll('}', '-')}`
+        : ''
+
+    const loc = `${sitemap ? DOMAIN_URL + '/' : ''}${
+      element.slug
+    }/${pathSuffix}`
+
+    if (sitemap) {
+      const url: SitemapUrl = { loc: '', lastmod: '' }
+      url.loc = loc
+      url.lastmod = new Date().toISOString()
+      urls.push(url)
+    } else {
+      urls.push(loc)
+    }
+  }
+
+  return urls
+}
+
+export default async function getReferenceEndpoints({
+  sitemap,
+}: {
+  sitemap: boolean
+}) {
+  const documents = await getNavigation()
+  const referenceCategories = documents.find(
+    (document: NavigationCategory) => document.documentation === 'API Reference'
+  )
+  let references: (SitemapUrl | string)[] = []
+  referenceCategories.categories.forEach((category: NavigationElement) => {
+    references = references.concat(getEndpoint(category, sitemap))
+  })
+  return references
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

To filter open API documents and load endpoints in build time. Also, to update reference routes by removing hash links (this will also improve Google indexing).

#### What problem is this solving?

- Improve reference page performance.
- The absence of Google search to endpoint pages.

#### How should this be manually tested?
Go to this preview and check if:
- Pages are loaded without doing requests to the entire Open API doc.
- The sidebar behavior's working with the new URL format AND the previous format (with hash links).
- `meta` tags also work in both cases above.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
