### PR TITLE
Feat/release notes filter

### DIFF
--- a/src/components/icons/checkbox.tsx
+++ b/src/components/icons/checkbox.tsx
@@ -1,0 +1,49 @@
+import type { IconProps } from '@vtex/brand-ui'
+import { Icon } from '@vtex/brand-ui'
+
+interface CheckboxProps extends IconProps {
+  checked: boolean
+}
+
+const CheckboxIcon = (props: CheckboxProps) => (
+  <Icon
+    {...props}
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    {!props.checked ? (
+      <>
+        <rect
+          x="0.5"
+          y="0.5"
+          width="19"
+          height="19"
+          rx="3.5"
+          fill="white"
+          fillOpacity="0.01"
+        />
+        <rect
+          x="0.5"
+          y="0.5"
+          width="19"
+          height="19"
+          rx="3.5"
+          stroke="#B9B9B9"
+        />
+      </>
+    ) : (
+      <>
+        <rect width="20" height="20" rx="4" fill="#0C1522" />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M16.0303 5.96968C16.3232 6.26258 16.3232 6.73746 16.0303 7.03034L9.03032 14.03C8.73743 14.3229 8.26259 14.3229 7.96969 14.03L4.46969 10.5304C4.17679 10.2375 4.17677 9.7626 4.46965 9.46969C4.76253 9.17679 5.2374 9.17677 5.53031 9.46965L8.49999 12.4391L14.9697 5.96966C15.2626 5.67677 15.7375 5.67678 16.0303 5.96968Z"
+          fill="white"
+        />
+      </>
+    )}
+  </Icon>
+)
+
+export default CheckboxIcon

--- a/src/components/multiselect/index.tsx
+++ b/src/components/multiselect/index.tsx
@@ -1,0 +1,100 @@
+import styles from './styles'
+import { Flex, Box, Button, IconCaret } from '@vtex/brand-ui'
+import CheckboxIcon from 'components/icons/checkbox'
+import { useState } from 'react'
+import { messages } from 'utils/constants'
+import { SelectOption } from 'utils/typings/types'
+
+interface MultiselectProps {
+  title: string
+  options: SelectOption[]
+  onSelect: (selection: SelectOption[]) => void
+}
+
+function getSelectionList(selection: SelectOption[]) {
+  if (selection.length > 0) {
+    const plus = selection.length > 1 ? ', +' + (selection.length - 1) : ''
+    return ': ' + selection[0].label + plus
+  }
+
+  return ''
+}
+
+const Multiselect = ({ title, options, onSelect }: MultiselectProps) => {
+  const [open, isOpen] = useState(false)
+  const [checked, setChecked] = useState<SelectOption[]>([])
+  const [selection, setSelection] = useState<SelectOption[]>([])
+
+  return (
+    <Box sx={styles.multiselect}>
+      <Flex
+        sx={styles.input}
+        onClick={() => {
+          if (!open) setChecked([...selection])
+          isOpen(!open)
+        }}
+      >
+        <Flex>
+          {title}
+          <span className="selectionText">{getSelectionList(selection)}</span>
+        </Flex>
+        <IconCaret direction={open ? 'up' : 'down'} size={24} />
+      </Flex>
+      <Flex sx={styles.dropdown} className={open ? '' : 'hidden'}>
+        <Flex sx={styles.optionsContainer}>
+          {options.map((option) => {
+            return (
+              <Flex
+                sx={styles.option}
+                onClick={() => {
+                  const index = checked.findIndex((value) => {
+                    return value.id === option.id
+                  })
+
+                  if (index < 0) setChecked([...checked, option])
+                  else {
+                    checked.splice(index, 1)
+                    setChecked([...checked])
+                  }
+                }}
+              >
+                <CheckboxIcon
+                  size={20}
+                  checked={checked.includes(option)}
+                  sx={styles.checkbox}
+                />
+                <Box>{option.label}</Box>
+              </Flex>
+            )
+          })}
+        </Flex>
+        <Flex sx={styles.buttonsContainer}>
+          <Button
+            variant="tertiary"
+            size="small"
+            onClick={() => {
+              setSelection([])
+              isOpen(false)
+              onSelect([])
+            }}
+          >
+            {messages['multiselect_clear_button']}
+          </Button>
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => {
+              setSelection([...checked])
+              isOpen(false)
+              onSelect(checked)
+            }}
+          >
+            {messages['multiselect_apply_button']}
+          </Button>
+        </Flex>
+      </Flex>
+    </Box>
+  )
+}
+
+export default Multiselect

--- a/src/components/multiselect/styles.ts
+++ b/src/components/multiselect/styles.ts
@@ -1,0 +1,67 @@
+import { SxStyleProp } from '@vtex/brand-ui'
+
+const multiselect: SxStyleProp = {
+  position: 'relative',
+  margin: '20px 0px',
+
+  '.hidden': {
+    visibility: 'hidden',
+  },
+
+  '.selectionText': {
+    color: '#000000',
+  },
+}
+
+const input: SxStyleProp = {
+  padding: '8px 12px 7px',
+  background: '#F4F4F4',
+  borderRadius: '4px',
+  justifyContent: 'space-between',
+  width: '230px',
+  cursor: 'pointer',
+}
+
+const dropdown: SxStyleProp = {
+  display: 'flex',
+  flexDirection: 'column',
+  padding: '20px 16px',
+  background: '#FFFFFF',
+  border: '1px solid #DDDDDD',
+  boxShadow: '0px 0px 16px rgba(0, 0, 0, 0.1)',
+  borderRadius: '4px',
+  position: 'absolute',
+  width: 'max-content',
+  top: 'calc(100% + 2px)',
+  zIndex: '3',
+}
+
+const optionsContainer: SxStyleProp = {
+  flexDirection: 'column',
+}
+
+const checkbox: SxStyleProp = {
+  ':hover': {
+    borderRadius: '4px',
+    boxShadow: '0px 0px 4px rgba(0, 0, 0, 0.2)',
+  },
+}
+
+const option: SxStyleProp = {
+  columnGap: '8px',
+  padding: '8px 0px',
+}
+
+const buttonsContainer: SxStyleProp = {
+  marginTop: '10px',
+}
+
+export default {
+  multiselect,
+  input,
+  dropdown,
+  optionsContainer,
+  checkbox,
+  option,
+  buttonsContainer,
+}

--- a/src/components/release-section/index.tsx
+++ b/src/components/release-section/index.tsx
@@ -4,16 +4,25 @@ import { Box, Flex, Text } from '@vtex/brand-ui'
 import styles from 'components/release-section/styles'
 import { getMessages } from 'utils/get-messages'
 import { compareDates, getDate } from './functions'
-import { UpdateElement } from 'utils/typings/types'
+import { SelectOption, UpdateElement } from 'utils/typings/types'
+import Multiselect from 'components/multiselect'
+import { useState } from 'react'
 
 const messages = getMessages()
 
 interface IReleasesData {
   releasesData: UpdateElement[]
+  actionTypes: SelectOption[]
 }
 
-const ReleaseSection = ({ releasesData }: IReleasesData) => {
-  const releases = releasesData.filter((release) => !release.hidden)
+const ReleaseSection = ({ releasesData, actionTypes }: IReleasesData) => {
+  const [filter, setFilter] = useState<SelectOption[]>([])
+  const releases = releasesData.filter(
+    (release) =>
+      !release.hidden &&
+      (filter.length === 0 ||
+        filter.some((option) => option.label === release.actionType))
+  )
   return (
     <Flex sx={styles.outerContainer}>
       <Box sx={styles.innerContainer}>
@@ -26,6 +35,13 @@ const ReleaseSection = ({ releasesData }: IReleasesData) => {
         <Box sx={styles.sectionDivider}>
           <hr />
         </Box>
+        <Multiselect
+          title={messages['release_notes_multiselect_text']}
+          options={actionTypes}
+          onSelect={(selection) => {
+            setFilter(selection)
+          }}
+        />
         {releases.map((release, index) => (
           <>
             {index > 0

--- a/src/messages/language.json
+++ b/src/messages/language.json
@@ -55,6 +55,7 @@
   "api_reference_sidebar_filter_clear": "Clear all",
   "release_notes_page.title": "Release Notes",
   "release_notes_page.subtitle": "Stay up to date with our latest releases",
+  "release_notes_multiselect_text": "All types",
   "api_reference_page.title": "API Reference",
   "api_reference_page.subtitle": "Use our API reference documentation to build custom solutions that fit your business.",
   "api_guides_page.title": "API Guides",
@@ -84,5 +85,7 @@
   "app_development_page_other_resources_help_center.description": "The Help Center contains beginner tutorials, reference guides and troubleshooting articles about the VTEX Admin panel.",
   "app_development_page_other_resources_support.description": "All clients have access to the services provided by our Technical Support team. These specialists are extensively prepared to give you the best experience possible when solving your tickets. To contact them, you need to open a ticket to VTEX support.",
   "relese-note-days-elapsed": "days ago",
-  "error_loading_image": "An error occurred while trying to load the image."
+  "error_loading_image": "An error occurred while trying to load the image.",
+  "multiselect_apply_button": "Apply",
+  "multiselect_clear_button": "Clear"
 }

--- a/src/pages/updates/release-notes/index.tsx
+++ b/src/pages/updates/release-notes/index.tsx
@@ -6,22 +6,28 @@ import ReleaseSection from '../../../components/release-section'
 
 import styles from 'styles/release-notes'
 import getReleasesData from 'utils/getReleasesData'
-import { UpdateElement } from 'utils/typings/types'
+import { SelectOption, UpdateElement } from 'utils/typings/types'
 import Head from 'next/head'
 import { getMessages } from 'utils/get-messages'
 import { PreviewContext } from 'utils/contexts/preview'
 import { useContext } from 'react'
+import getActionTypes from 'utils/getActionTypes'
 
 interface Props {
   sidebarfallback: any //eslint-disable-line
   sectionSelected?: DocumentationTitle | UpdatesTitle | ''
   releasesData: UpdateElement[]
+  actionTypes: SelectOption[]
   branch: string
 }
 
 const messages = getMessages()
 
-const ReleasePage: NextPage<Props> = ({ releasesData, branch }) => {
+const ReleasePage: NextPage<Props> = ({
+  releasesData,
+  actionTypes,
+  branch,
+}) => {
   const { setBranchPreview } = useContext(PreviewContext)
   setBranchPreview(branch)
   return (
@@ -35,7 +41,7 @@ const ReleasePage: NextPage<Props> = ({ releasesData, branch }) => {
         />
       </Head>
       <Flex sx={styles.container}>
-        <ReleaseSection releasesData={releasesData} />
+        <ReleaseSection releasesData={releasesData} actionTypes={actionTypes} />
       </Flex>
     </>
   )
@@ -53,12 +59,14 @@ export const getStaticProps: GetStaticProps = async ({
       : 'main'
   const branch = preview ? previewBranch : 'main'
   const releasesData = await getReleasesData(branch)
+  const actionTypes = getActionTypes(releasesData)
 
   return {
     props: {
       sidebarfallback,
       sectionSelected,
       releasesData,
+      actionTypes,
       branch,
     },
   }

--- a/src/utils/getActionTypes.ts
+++ b/src/utils/getActionTypes.ts
@@ -1,0 +1,14 @@
+import { UpdateElement } from './typings/types'
+
+export default function getActionTypes(releaseData: UpdateElement[]) {
+  const uniqueActionTypes = [
+    ...new Set(releaseData.map((obj) => obj.actionType).filter(Boolean)),
+  ]
+
+  const actionTypes = uniqueActionTypes.map((actionType, index) => ({
+    id: (index + 1).toString(),
+    label: actionType,
+  }))
+
+  return actionTypes
+}

--- a/src/utils/typings/types.ts
+++ b/src/utils/typings/types.ts
@@ -46,3 +46,8 @@ export type ResourceDataElement = {
   description: string
   link: string
 }
+
+export type SelectOption = {
+  id: string
+  label: string
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

To add a filter by action type to the release notes page.

#### What problem is this solving?

The user could not filter the release notes by action types.

#### How should this be manually tested?

Open the release notes page and use the filter.

#### Screenshots or example usage

https://github.com/vtexdocs/devportal/assets/62757720/6ebcdf59-12cd-4159-bd67-df23c8a2107b

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
