### PR TITLE
Fix/search page style

### DIFF
--- a/src/components/search-card/index.tsx
+++ b/src/components/search-card/index.tsx
@@ -37,7 +37,7 @@ const SearchCard = ({
   hit,
 }: SearchCardProps) => {
   const actionValue = actionType ? getAction(actionType) : null
-  const [toggleChildResults, setToggleChildResults] = useState<boolean>(false)
+  const [toggleChildResults, setToggleChildResults] = useState<boolean>(true)
   return (
     <Link href={url} legacyBehavior>
       <Flex sx={styles.containerActive(method)}>

--- a/src/components/search-card/styles.ts
+++ b/src/components/search-card/styles.ts
@@ -11,7 +11,7 @@ const container: SxStyleProp = {
   paddingTop: '26px',
   paddingBottom: '10px',
   paddingLeft: ['13px', '44px'],
-  paddingRight: '13px',
+  paddingRight: ['13px', '34px'],
   background: '#FFFFFF',
   cursor: 'pointer',
 }

--- a/src/components/search-input/customHighlight.tsx
+++ b/src/components/search-input/customHighlight.tsx
@@ -120,7 +120,7 @@ const Highlight = ({
       className="hit-content-title"
       sx={styles.hitContentContainer}
     >
-      <Text sx={styles.hitContent}>
+      <Text sx={searchPage ? styles.hitContent : styles.hitContentSmall}>
         {(searchPage ? ellipsedContent : parsedHit).map(
           (part: HitHighlightProps, index: number) =>
             part.isHighlighted ? (

--- a/src/components/search-input/styles.ts
+++ b/src/components/search-input/styles.ts
@@ -60,6 +60,13 @@ const hitContent: SxStyleProp = {
   fontSize: ['14px', '16px'],
   lineHeight: ['20px', '22px'],
   width: '100%',
+}
+
+const hitContentSmall: SxStyleProp = {
+  color: 'muted.0',
+  fontSize: ['14px', '16px'],
+  lineHeight: ['20px', '22px'],
+  width: '100%',
   whiteSpace: 'pre',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
@@ -158,6 +165,7 @@ export default {
   hitIcon,
   hitContentContainer,
   hitContent,
+  hitContentSmall,
   hitBreadCrumb,
   hitBreadCrumbIn,
   hitBreadCrumbArrow,

--- a/src/components/search-results/index.tsx
+++ b/src/components/search-results/index.tsx
@@ -22,7 +22,8 @@ const SearchResults = () => {
     <Box sx={styles.resultContainer}>
       <Text sx={styles.resultText}>
         Showing {ocurrenceCount[filterSelectedSection]} results for "
-        {router.query.keyword}" in all results
+        {router.query.keyword}" in{' '}
+        {!filterSelectedSection ? `all results` : filterSelectedSection}
       </Text>
       <hr />
       <Box>

--- a/src/components/search-results/styles.ts
+++ b/src/components/search-results/styles.ts
@@ -39,10 +39,10 @@ const paginationLinkDisabled: SxStyleProp = {
 
 const paginationNumber: SxStyleProp = {
   display: 'flex',
-  fontSize: '16px',
+  fontSize: ['14px', '16px'],
   lineHeight: '20px',
   color: '#4A596B',
-  mx: '27px',
+  mx: ['18px', '27px'],
 }
 
 const paginationActualNumber: SxStyleProp = {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix some style issues in Search Page

#### What problem is this solving?

- Adjust the right margin of the result card.
- If the result is large text, break the line instead of using ellipses.
- Fix pagination text on small mobile screens.
- Cards with more than one result should be open by default
- The text "Showing X results for ..." shows only "all results" even though the user selects a filter.

#### Screenshots or example usage
|before|after|
|-----|-----|
|![image](https://github.com/vtexdocs/devportal/assets/42784961/621777db-8d02-4cb3-9802-c92989ce8c8c)|![image](https://github.com/vtexdocs/devportal/assets/42784961/7ccbcf93-0fee-4786-aabb-d79bf70fabed)|
|![image](https://github.com/vtexdocs/devportal/assets/42784961/4902144f-49a9-4f21-a575-f77c2e824672)|![image](https://github.com/vtexdocs/devportal/assets/42784961/86ad3dc1-07a8-41d1-ac10-bc933e9e31b7)|
|![image](https://github.com/vtexdocs/devportal/assets/42784961/de61a94c-4b67-44ba-8275-f88b44eb033b)|![image](https://github.com/vtexdocs/devportal/assets/42784961/4e27a659-35f9-47d8-ad95-57b9e2039e44)|
|![image](https://github.com/vtexdocs/devportal/assets/42784961/c4d6f2b8-ef99-4c18-b5ef-1777486b4571)|![image](https://github.com/vtexdocs/devportal/assets/42784961/82aa72f8-01f5-443c-9dd9-5157a133e66b)|






#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
