### PR TITLE
Update navigation.json

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -13012,7 +13012,6 @@
                   "type": "markdown",
                   "children": []
                 },
-                
                 {
                   "name": "Master Data v2 orders entity deprecation",
                   "slug": "master-data-v2-orders-entity-deprecation",

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -13012,6 +13012,7 @@
                   "type": "markdown",
                   "children": []
                 },
+                
                 {
                   "name": "Master Data v2 orders entity deprecation",
                   "slug": "master-data-v2-orders-entity-deprecation",

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -12977,13 +12977,6 @@
               "type": "category",
               "children": [
                 {
-                  "name": "New field now available in Promotion object",
-                  "slug": "new-field-now-available-in-promotion-object",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
                   "name": "Get ready for Google Analytics 4 with VTEX's new Google Tag Manager version app",
                   "slug": "2023-05-04-google-tag-manager-new-version",
                   "origin": "",
@@ -13008,6 +13001,13 @@
                 {
                   "name": "New Coupons v2 API",
                   "slug": "new-coupons-v2-api",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
+                  "name": "New field now available in Promotion object",
+                  "slug": "2023-04-23-new-field-now-available-in-promotion-object",
                   "origin": "",
                   "type": "markdown",
                   "children": []


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the slug to the [New field now available in Promotion object](https://developers.vtex.com/docs/guides/2023-05-24-new-field-now-available-in-promotion-object) release notes

#### What problem is this solving?

I can access this release note only if I have the link or search for it on the portal. Since the slug was updated (reference: [#523](https://github.com/vtexdocs/dev-portal-content/pull/523#pullrequestreview-1477076111)), I updated the `navigation.json` to reflect the new slug and render the doc.

P.s.: The preview probably won't work until we approve the [#523](https://github.com/vtexdocs/dev-portal-content/pull/523#pullrequestreview-1477076111).

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

