### PR TITLE
Feat/postman collection

### DIFF
--- a/src/pages/api/portman/[slug].tsx
+++ b/src/pages/api/portman/[slug].tsx
@@ -1,0 +1,88 @@
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+}
+
+const referencePaths = objectFlip({
+  'VTEX - Antifraud Provider API': 'antifraud-provider-protocol',
+  'VTEX - CMS API': 'cms-api',
+  'VTEX - Catalog API Seller Portal': 'catalog-api-seller-portal',
+  'VTEX - Catalog API': 'catalog-api',
+  'VTEX - Checkout API': 'checkout-api',
+  'VTEX - Customer Credit API': 'customer-credit-api',
+  'VTEX - GiftCard Hub API': 'giftcard-hub-api',
+  'VTEX - Giftcard API': 'giftcard-api',
+  'VTEX - Giftcard Provider Protocol': 'giftcard-provider-protocol',
+  'VTEX - Headless CMS API': 'headless-cms-api',
+  'VTEX - Intelligent Search API': 'intelligent-search-api',
+  'VTEX - License Manager API': 'license-manager-api',
+  'VTEX - Logistics API': 'logistics-api',
+  'VTEX - Marketplace APIs': 'marketplace-apis',
+  'VTEX - Marketplace APIs - Suggestions': 'marketplace-apis-suggestions',
+  'VTEX - Marketplace APIs - Sent Offers': 'marketplace-apis-offer-management',
+  'VTEX - Marketplace Protocol - External Marketplace Mapper':
+    'marketplace-protocol-external-marketplace-mapper',
+  'VTEX - Marketplace Protocol - External Marketplace Orders':
+    'marketplace-protocol-external-marketplace-orders',
+  'VTEX - Marketplace Protocol - External Seller Fulfillment':
+    'marketplace-protocol-external-seller-fulfillment',
+  'VTEX - Marketplace Protocol - External Seller Marketplace':
+    'marketplace-protocol',
+  'VTEX - Master Data API - v2': 'master-data-api-v2',
+  'VTEX - MasterData API - v10.2': 'masterdata-api',
+  'VTEX - Message Center API': 'message-center-api',
+  'VTEX - Orders API (PII version)': 'orders-api-pii-version',
+  'VTEX - Orders API': 'orders-api',
+  'VTEX - Payment Provider Protocol': 'payment-provider-protocol',
+  'VTEX - Payments Gateway API': 'payments-gateway-api',
+  'VTEX - Policies System API': 'policies-system-api',
+  'VTEX - Price Simulations': 'price-simulations',
+  'VTEX - Pricing API': 'pricing-api',
+  'VTEX - Pricing Hub': 'pricing-hub',
+  'VTEX - Profile System': 'profile-system',
+  'VTEX - Promotions & Taxes API': 'promotions-and-taxes-api',
+  'VTEX - Recurrence (v1 - deprecated)': 'recurrence-v1-deprecated',
+  'VTEX - Reviews and Ratings API': 'reviews-and-ratings-api',
+  'VTEX - SKU Bindings API': 'sku-bindings-api',
+  'VTEX - Search API': 'search-api',
+  'VTEX - Session Manager API': 'session-manager-api',
+  'VTEX - Subscriptions API (v2)': 'subscriptions-api-v2',
+  'VTEX - Subscriptions API (v3)': 'subscriptions-api-v3',
+  'VTEX - Tracking': 'tracking',
+  'VTEX - VTEX Do API': 'vtex-do-api',
+  'VTEX - VTEX ID API': 'vtex-id-api',
+  'VTEX - VTEX Shipping Network API': 'vtex-shipping-network-api',
+  'VTEX - Promotions & Taxes API - v2': 'promotions-and-taxes-api-v2',
+})
+
+function objectFlip(obj: { [x: string]: string }) {
+  return Object.keys(obj).reduce((ret, key) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    ret[obj[key]] = key
+    return ret
+  }, {})
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default async function handler(req: any, res: any) {
+  const { slug } = req.query
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const path = referencePaths[slug] || ''
+  if (path) {
+    const response = await fetch(
+      `https://raw.githubusercontent.com/vtex/openapi-schemas/master/portman/${path}.json`
+    )
+    const body = await response.text()
+    res
+      .setHeader(
+        'Cache-Control',
+        'public, s-maxage=300, stale-while-revalidate=250'
+      )
+      .send(body)
+  } else {
+    res.status(404)
+  }
+}

--- a/src/pages/api/postman/[slug].tsx
+++ b/src/pages/api/postman/[slug].tsx
@@ -73,7 +73,7 @@ export default async function handler(req: any, res: any) {
   const path = referencePaths[slug] || ''
   if (path) {
     const response = await fetch(
-      `https://raw.githubusercontent.com/vtex/openapi-schemas/master/portman/${path}.json`
+      `https://raw.githubusercontent.com/vtex/openapi-schemas/master/PostmanCollections/${path}.json`
     )
     const body = await response.text()
     res

--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -147,6 +147,7 @@ const APIPage: NextPage<Props> = ({
         <rapi-doc
           ref={rapidoc}
           spec-url={`/api/openapi/${slug}`}
+          postman-url={`/api/portman/${slug}`}
           spec={doc}
           layout="column"
           render-style="focused"

--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -147,7 +147,7 @@ const APIPage: NextPage<Props> = ({
         <rapi-doc
           ref={rapidoc}
           spec-url={`/api/openapi/${slug}`}
-          postman-url={`/api/portman/${slug}`}
+          postman-url={`/api/postman/${slug}`}
           spec={doc}
           layout="column"
           render-style="focused"


### PR DESCRIPTION
Related tasks: 
- [Utilizar portman para gerar Postman Collection a partir de OpenAPI spec](https://www.notion.so/vtexhandbook/Utilizar-portman-para-gerar-Postman-Collection-a-partir-de-OpenAPI-spec-7b0e0e5df5d84ccc8aa615ac536a4369)
- [Corrigir URL do Curl](https://www.notion.so/vtexhandbook/Corrigir-URL-do-Curl-45503e3cc7f04278a189664e0431e200)

Related RapiDoc PR:
- [Pull Request #38](https://github.com/vtexdocs/RapiDoc/pull/38)

#### What is the purpose of this pull request?

- To add the option to view/download the corresponding postman collection file from a openAPI schema in the API Reference pages.
- And to fix the URL shown in the cURL code.

#### What problem is this solving?

- Users were not able to import the openAPI schemas to Postman.
- The URL in the cURL code was missing a '/'.

#### How should this be manually tested?

Open any API Reference page, check if you are able to view and download the corresponding postman collection and check if when imported in Postman the collection content is correct.

You can also check the endpoint /api/postman/{name}

#### Screenshots or example usage

Buttons on top of the page:
![image](https://github.com/vtexdocs/devportal/assets/62757720/00209542-62c0-4f4b-b915-17d55b01be3b)

Imported file in Postman:
![image](https://github.com/vtexdocs/devportal/assets/62757720/cfccf1ca-5be5-40c2-8560-e2622828fc63)

Fixed URL:
![image](https://github.com/vtexdocs/devportal/assets/62757720/e2f41398-edc1-458d-ab50-dd064e3f313d)


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
