### PR TITLE
Preview API Endpoint Auth

### DIFF
--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -46,8 +46,8 @@ export default async function handler(
     }
     res.redirect('/')
   } else {
-    res
-      .status(401)
-      .json({ err: 'You need to be authenticated to use this route' })
+    const protocol = process.env.NETLIFY ? 'https' : 'http'
+    const callbackUrl = `${protocol}://${req.headers.host}${req.url}`
+    res.redirect(`/api/auth/signin?callbackUrl=${callbackUrl}`)
   }
 }

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -46,7 +46,7 @@ export default async function handler(
     }
     res.redirect('/')
   } else {
-    const protocol = process.env.NETLIFY ? 'https' : 'http'
+    const protocol = process.env.BUILD_ENV === 'dev' ? 'http' : 'https'
     const callbackUrl = `${protocol}://${req.headers.host}${req.url}`
     res.redirect(`/api/auth/signin?callbackUrl=${callbackUrl}`)
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To add a redirect to the login page when a non-authenticated user tries to access the API preview endpoint.

#### What problem is this solving?

When a non-authenticated user tries to reach the API preview endpoint, they only get an error telling them they're not authenticated, but no means to actually authenticate.

#### How should this be manually tested?

This can only be tested locally or in production. Try pulling this branch to your local copy of this repository, setting the `BUILD_ENV` envinronment variable to `dev` in your `.env.local` file and trying to access the `/api/preview?branch=main` endpoint. If you are not authenticated, it should redirect you to the login page and then back to the home page with a warning at the top (telling you are using the portal in the preview mode).

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
