### PR TITLE
Hide search card full description

### DIFF
--- a/src/components/search-card/index.tsx
+++ b/src/components/search-card/index.tsx
@@ -37,7 +37,7 @@ const SearchCard = ({
   hit,
 }: SearchCardProps) => {
   const actionValue = actionType ? getAction(actionType) : null
-  const [toggleChildResults, setToggleChildResults] = useState<boolean>(true)
+  const [toggleChildResults, setToggleChildResults] = useState<boolean>(false)
   return (
     <Link href={url} legacyBehavior>
       <Flex sx={styles.containerActive(method)}>


### PR DESCRIPTION
#### What is the purpose of this pull request?

To make the full description of the search cards hidden by default.

#### What problem is this solving?

Users of the Developers Portal have shown preference to have the search cards hide the full description by default and only show it when requested.

#### How should this be manually tested?

Open the deploy preview and try searching for something. Go through the results and look for the ones with an eye icon by the right side. Make sure it is crossed (off) by default. Try clicking it and make sure the full description of the card now shows.

#### Screenshots or example usage

![image](https://github.com/vtexdocs/devportal/assets/37647055/407d08e7-f327-48d9-9693-bfdc4e6c5647)
![image](https://github.com/vtexdocs/devportal/assets/37647055/51fb9f30-2b07-40da-8a33-b57d2cf6ae06)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
