### PR TITLE
docs: create redirect catalog api seller portal

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -667,3 +667,9 @@ force = true
 from = '/docs/guides/pii-platform-version'
 status = 308
 to = '/docs/guides/pii-data-architecture'
+
+[[redirects]]
+force = true
+from = "/docs/api-reference/catalog-api-seller-portal-overview"
+status = 308
+to = "/docs/api-reference/catalog-api-seller-portal"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Creating a redirect from https://developers.vtex.com/docs/api-reference/catalog-api-seller-portal-overview to https://developers.vtex.com/docs/api-reference/catalog-api-seller-portal

#### What problem is this solving?

[EDU-10264](https://vtex-dev.atlassian.net/browse/EDU-10264) Feedback #3133 - Error

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
