### PR TITLE
docs(navigation): restore webservice legacy pdf

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -673,3 +673,9 @@ force = true
 from = "/docs/api-reference/catalog-api-seller-portal-overview"
 status = 308
 to = "/docs/api-reference/catalog-api-seller-portal"
+
+[[redirects]]
+force = true
+from = "/docs/guides/webservice-deprecated"
+status = 308
+to = "https://assets.ctfassets.net/alneenqid6w5/4OdeCFbcVQtEgkuWsuuidl/80b79448cf2b327e07b567a8411afaa0/vtex_WebServiceGuide.pdf"

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -817,6 +817,13 @@
               "type": "markdown",
               "children": []
             }
+            {
+              "name": "Webservice (Legacy)",
+              "slug": "webservice-deprecated",
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            }
           ]
         },
         {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Restoring Webservice guide as requested in [EDU-9964](https://vtex-dev.atlassian.net/browse/EDU-9964), since this service is not deprecated. Adding it to navigation and creating a redirect to the pdf file with the legacy guide.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
