### PR TITLE
fix(sitemap): remove guides page with noindex from sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -6,7 +6,7 @@ const siteUrl = process.env.NEXT_PUBLIC_DOMAIN_URL
 module.exports = {
   transform: async (config, path) => {
     const noIndexRegex = /(<meta.*(content="noindex").*\/>)/gm
-    const filepath = `./.next/server/pages/${path}.html`
+    const filepath = `./.next/server/pages/en${path}.html`
 
     if (fs.existsSync(filepath)) {
       try {

--- a/src/pages/docs/guides/[slug].tsx
+++ b/src/pages/docs/guides/[slug].tsx
@@ -86,6 +86,8 @@ const DocumentationPage: NextPage<Props> = ({
   sectionSelected,
 }) => {
   const headings: Item[] = headingList
+  const hidden =
+    sectionSelected === '' || serialized.frontmatter.hidden === true
   const { setBranchPreview } = useContext(PreviewContext)
   const { setActiveSidebarElement } = useContext(SidebarContext)
   useEffect(() => {
@@ -101,9 +103,7 @@ const DocumentationPage: NextPage<Props> = ({
           name="docsearch:doctitle"
           content={serialized.frontmatter?.title as string}
         />
-        {serialized.frontmatter?.hidden && (
-          <meta name="robots" content="noindex" />
-        )}
+        {hidden && <meta name="robots" content="noindex" />}
         {serialized.frontmatter?.excerpt && (
           <meta
             property="og:description"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove Guides pages with `noindex` meta tag from the sitemap. (Prevent Algolia indexing)

#### How should this be manually tested?

Go to [frontmatter](https://deploy-preview-434--elated-hoover-5c29bf.netlify.app/sitemap-0.xml) and check if the path from any page with:
- `hidden: true` in frontmatter
- `sectionSelected` empty (it isn't in navigation.json)

#### Screenshots or example usage

https://github.com/vtexdocs/devportal/assets/42784961/7abe87e7-a105-4cf0-8364-1290f56c49a2

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
