### PR TITLE
Update/api reference endpoints url

### DIFF
--- a/src/components/sidebar-elements/index.tsx
+++ b/src/components/sidebar-elements/index.tsx
@@ -49,7 +49,10 @@ const SidebarElements = ({ slugPrefix, items, subItemLevel }: SidebarProps) => {
     slug: string
   ) => {
     e.preventDefault()
-    router.push(getHref(slugPrefix || '', pathSuffix, slug))
+    const hasEndpointQuery = router.query.endpoint
+    router.push(getHref(slugPrefix || '', pathSuffix, slug)).then(() => {
+      if (hasEndpointQuery) router.reload()
+    })
   }
 
   // eslint-disable-next-line

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -56,14 +56,17 @@ const Sidebar = ({ parentsArray = [] }: SideBarSectionState) => {
   if (querySlug && router.pathname === '/docs/api-reference/[slug]') {
     activeSlug = router.asPath.replace('/docs/api-reference/', '')
     const docPath = activeSlug.split('/')
-    const apiSlug = docPath[0].split('#')[0]
+    const hasHashTag = router.asPath.indexOf('#') > -1
+    const apiSlug = docPath[0].split(hasHashTag ? '#' : '?endpoint=')[0]
     const endpoint = '/' + docPath.splice(1, docPath.length).join('/')
     let keyPath
     if (endpoint == '/') {
       activeSlug = apiSlug
       keyPath = getKeyByEndpoint(flattenedSidebar, '', apiSlug)
     } else {
-      const method = docPath[0].split('#')[1].split('-')[0]
+      const method = docPath[0]
+        .split(hasHashTag ? '#' : '?endpoint=')[1]
+        .split('-')[0]
       keyPath = getKeyByEndpoint(flattenedSidebar, endpoint, apiSlug, method)
     }
     parentsArray.push(activeSlug)
@@ -80,7 +83,7 @@ const Sidebar = ({ parentsArray = [] }: SideBarSectionState) => {
     parentsArray.forEach((slug: string) => {
       openSidebarElement(slug)
     })
-    setActiveSidebarElement(activeSlug)
+    setActiveSidebarElement(activeSlug?.replace('?endpoint=', '#'))
     return () => {
       clearTimeout(timer)
     }

--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -82,15 +82,18 @@ const APIPage: NextPage<Props> = ({
   }>(null)
   const pageTitle =
     capitalize(slug.replaceAll('-', ' ').replace('api', '')) + ' API'
+  const hasHashTag = router.asPath.indexOf('#') > -1
+  const cleanPath = hasHashTag
+    ? router.asPath.split('#')[1]
+    : router.asPath.split('?endpoint=')[1] || ''
 
   const getMethod = () => {
-    const regexMethodMatches = router.asPath.match(/#(.*?)-/) || ''
-    const method = regexMethodMatches ? regexMethodMatches[1].toUpperCase() : ''
-    return method && isMethodType(method) ? method : ''
+    const method = cleanPath.split('/')[0].replace('-', '').toUpperCase()
+    return isMethodType(method) ? method : ''
   }
+
   const httpMethod: MethodType | '' = getMethod()
-  const hash = router.asPath.split('#')[1]
-  const endpointPath = hash ? `#${hash}` : slug
+  const endpointPath = cleanPath ? `#${cleanPath}` : slug
   const pag: Pagination = {
     previousDoc: {
       name: null,

--- a/src/pages/server-sitemap.xml/index.ts
+++ b/src/pages/server-sitemap.xml/index.ts
@@ -16,7 +16,7 @@ function getEndpoint(element: any) {
   if (element.type === 'openapi') {
     const url: any = {}
     const pathSuffix = element.method
-      ? `#${element.method.toLowerCase()}-${element.endpoint
+      ? `?endpoint=${element.method.toLowerCase()}-${element.endpoint
           .replaceAll('{', '-')
           .replaceAll('}', '-')}`
       : ''


### PR DESCRIPTION
#### What is the purpose of this pull request?

Generate server sitemap passing endpoint path as query param (`endpoint`) to enable Google crawl on these pages.

#### How should this be manually tested?
1. Open the server sitemap (link).
2. Check if the sitemap URL work (changing URL domains).
3. Check if the sidebar (changing URL domains) shows the current page correctly.
4. Check if changing `?endpoint=` to `#` works the same.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
