### PR TITLE
Fix: Headless CMS endpoint path

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -5075,7 +5075,7 @@
                   "type": "openapi",
                   "method": "GET",
                   "origin": "",
-                  "endpoint": "/_v/cms/api/-builderId-/",
+                  "endpoint": "/_v/cms/api/-projectId-/",
                   "children": []
                 },
                 {
@@ -5084,7 +5084,7 @@
                   "type": "openapi",
                   "method": "GET",
                   "origin": "",
-                  "endpoint": "/_v/cms/api/-builderId-/-content-type-",
+                  "endpoint": "/_v/cms/api/-projectId-/-content-type-",
                   "children": []
                 },
                 {
@@ -5093,7 +5093,7 @@
                   "type": "openapi",
                   "method": "GET",
                   "origin": "",
-                  "endpoint": "/_v/cms/api/-builderId-/-content-type-/-document-id-/",
+                  "endpoint": "/_v/cms/api/-projectId-/-content-type-/-document-id-/",
                   "children": []
                 }
               ]


### PR DESCRIPTION
#### What is the purpose of this pull request?
Since the changes in the [Headless CMS API doc](https://developers.vtex.com/docs/api-reference/headless-cms-api#overview) (more info in the [943 PR)](https://github.com/vtex/openapi-schemas/pull/943), the paths for each documentation endpoint are not matching the updates and are currently not rendering the content in the Dev Portal. This PR is to fix this issue.

#### How to test 
The path for each endpoint page should contain `projectId` and not `builderId`.

Example: `https://deploy-preview-457--elated-hoover-5c29bf.netlify.app/docs/api-reference/headless-cms-api#get-/_v/cms/api/-projectId-/`

[Preview example](https://deploy-preview-457--elated-hoover-5c29bf.netlify.app/docs/api-reference/headless-cms-api#get-/_v/cms/api/-projectId-/)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
