### PR TITLE
feat(api-reference): openapi preview

### DIFF
--- a/src/pages/editor/openapi-preview.tsx
+++ b/src/pages/editor/openapi-preview.tsx
@@ -69,16 +69,14 @@ const OpenAPIPreviewPage: Page<Props> = () => {
       </Head>
       <Box sx={styles.previewContainer}>
         <PageHeader
-          title="Markdown Preview"
-          description="Use the markdown editor below and preview the rendered page to the side."
+          title="OpenAPI Preview"
+          description="Preview the rendered OpenAPI below. This is an overview and you can expand the endpoints by clicking on them"
           imageUrl={image}
-          imageAlt="Markdown Preview"
+          imageAlt="OpenAPI Preview image"
         />
         <Box sx={styles.previewContent}>
           <rapi-doc
             ref={rapidoc}
-            spec-url={''}
-            // postman-url={`/api/postman/${slug}`}
             spec={spec}
             layout="column"
             render-style="view"

--- a/src/pages/editor/openapi-preview.tsx
+++ b/src/pages/editor/openapi-preview.tsx
@@ -70,7 +70,7 @@ const OpenAPIPreviewPage: Page<Props> = () => {
       <Box sx={styles.previewContainer}>
         <PageHeader
           title="OpenAPI Preview"
-          description="Preview the rendered OpenAPI below. This is an overview and you can expand the endpoints by clicking on them"
+          description="Preview the rendered OpenAPI below. This is an overview and you can expand the endpoints by clicking on them."
           imageUrl={image}
           imageAlt="OpenAPI Preview image"
         />
@@ -79,6 +79,7 @@ const OpenAPIPreviewPage: Page<Props> = () => {
             ref={rapidoc}
             spec={spec}
             layout="column"
+            route-prefix="#"
             render-style="view"
             show-header="false"
             show-side-nav="false"

--- a/src/pages/editor/openapi-preview.tsx
+++ b/src/pages/editor/openapi-preview.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/router'
+import Head from 'next/head'
+import { Box } from '@vtex/brand-ui'
+import SwaggerParser from '@apidevtools/swagger-parser'
+
+import Auth from 'components/auth'
+import PageHeader from 'components/page-header'
+import type { Page } from 'utils/typings/types'
+import image from '../../../public/images/editor.png'
+import '../../../RapiDoc/src/rapidoc.js'
+
+import styles from 'styles/openapi-preview'
+
+interface Props {
+  isPRPreview: boolean
+  isPreview: boolean
+}
+
+const OpenAPIPreviewPage: Page<Props> = () => {
+  const router = useRouter()
+  const rapidoc = useRef<{
+    shadowRoot: Node
+    scrollToPath: (endpoint: string) => void
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    resolvedSpec: any
+  }>(null)
+  const [spec, setSpec] = useState('')
+  const { branch, file } = router.query as { [attr: string]: string }
+
+  useEffect(() => {
+    function getEndpointPreview(branch: string, file: string) {
+      fetch(
+        `https://raw.githubusercontent.com/vtex/openapi-schemas/${branch}/${file}`
+      )
+        .then((res) => res.json())
+        .then((data) => SwaggerParser.dereference(data))
+        .then((deReferencedRaw) => SwaggerParser.parse(deReferencedRaw))
+        .then((parsedFile) => {
+          const previewDoc = JSON.stringify(parsedFile)
+          setSpec(previewDoc)
+        })
+    }
+    if (branch) {
+      console.log('entrou')
+      getEndpointPreview(branch, file)
+    }
+  }, [router.query])
+
+  useEffect(() => {
+    const scrollDoc = () => {
+      if (rapidoc.current) {
+        rapidoc.current.scrollToPath(
+          window.location.hash.slice(1) || 'overview'
+        )
+      }
+    }
+
+    router.events.on('hashChangeComplete', scrollDoc)
+    return () => {
+      router.events.off('hashChangeComplete', scrollDoc)
+    }
+  }, [])
+
+  return (
+    <Auth>
+      <Head>
+        <title>OpenAPI Preview</title>
+        <meta name="robots" content="noindex" />
+      </Head>
+      <Box sx={styles.previewContainer}>
+        <PageHeader
+          title="Markdown Preview"
+          description="Use the markdown editor below and preview the rendered page to the side."
+          imageUrl={image}
+          imageAlt="Markdown Preview"
+        />
+        <Box sx={styles.previewContent}>
+          <rapi-doc
+            ref={rapidoc}
+            spec-url={''}
+            // postman-url={`/api/postman/${slug}`}
+            spec={spec}
+            layout="column"
+            render-style="view"
+            show-header="false"
+            show-side-nav="false"
+            default-schema-tab="schema"
+            fill-request-fields-with-example={true}
+            theme="light"
+            bg-color="#FFFFFF"
+            primary-color="#142032"
+            regular-font="VTEX Trust Regular"
+            mono-font="Consolas,monaco,monospace"
+            medium-font="VTEX Trust Medium"
+            load-fonts={false}
+            schema-style="table"
+            schema-description-expanded={true}
+            id="the-doc"
+            allow-spec-file-download={true}
+          />
+        </Box>
+      </Box>
+    </Auth>
+  )
+}
+
+OpenAPIPreviewPage.hideSidebar = true
+OpenAPIPreviewPage.isEditor = true
+
+export default OpenAPIPreviewPage

--- a/src/pages/editor/openapi-preview.tsx
+++ b/src/pages/editor/openapi-preview.tsx
@@ -4,7 +4,6 @@ import Head from 'next/head'
 import { Box } from '@vtex/brand-ui'
 import SwaggerParser from '@apidevtools/swagger-parser'
 
-import Auth from 'components/auth'
 import PageHeader from 'components/page-header'
 import type { Page } from 'utils/typings/types'
 import image from '../../../public/images/editor.png'
@@ -63,7 +62,7 @@ const OpenAPIPreviewPage: Page<Props> = () => {
   }, [])
 
   return (
-    <Auth>
+    <>
       <Head>
         <title>OpenAPI Preview</title>
         <meta name="robots" content="noindex" />
@@ -101,7 +100,7 @@ const OpenAPIPreviewPage: Page<Props> = () => {
           />
         </Box>
       </Box>
-    </Auth>
+    </>
   )
 }
 

--- a/src/styles/openapi-preview.ts
+++ b/src/styles/openapi-preview.ts
@@ -1,0 +1,16 @@
+import type { SxStyleProp } from '@vtex/brand-ui'
+
+const previewContainer: SxStyleProp = {
+  background: 'transparent',
+  height: 'auto',
+}
+
+const previewContent: SxStyleProp = {
+  maxWidth: '90%',
+  margin: '0px auto',
+}
+
+export default {
+  previewContainer,
+  previewContent,
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add an open API preview feature to create a link preview for PRs in openapi-schemas repository.

#### What problem is this solving?

The absence of an open API preview 

#### How should this be manually tested?

Using these URL query params:
`/editor/openapi-preview?branch=${branch}&file=${file.json}`
We can define the respective branch and file to be previewed.
For example:
[https://deploy-preview-464--elated-hoover-5c29bf.netlify.app/editor/openapi-preview?branch=master&file=VTEX - Catalog API.json](https://deploy-preview-464--elated-hoover-5c29bf.netlify.app/editor/openapi-preview?branch=master&file=VTEX%20-%20Catalog%20API.json)

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
