### PR TITLE
fix(hamburger): fix and scroll and hide menu correctly

### DIFF
--- a/src/components/header/styles.ts
+++ b/src/components/header/styles.ts
@@ -9,6 +9,8 @@ const cardContainer: SxStyleProp = {
   display: 'flex',
   flexDirection: 'column',
   width: '100vw',
+  overflowY: 'scroll',
+  height: 'calc(100vh - 5rem)',
 }
 
 const sideMenuContainer: SxStyleProp = {
@@ -29,6 +31,7 @@ const headerContainer: SxStyleProp = {
 }
 
 const hamburgerContainer: SxStyleProp = {
+  display: ['block', 'block', 'block', 'none'],
   backgroundColor: '#ffff',
   width: '100%',
   '.menuHidden': {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix the hamburger menu scrolling on mobile.

#### What problem is this solving?

The scroll did not work correctly and sometimes the user could not see all the items listed.

#### How should this be manually tested?

Open the preview and try to use the hamburger menu. Test it in different breakpoints and also try to change the browser width to see how it will behave.

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
