### PR TITLE
fix(api-reference): try to stop category indexing to prevent no-canon…

### DIFF
--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -131,6 +131,7 @@ const APIPage: NextPage<Props> = ({
     <>
       <Head>
         <title>{endpointNames[endpointPath]}</title>
+        {endpointPath === slug && <meta name="robots" content="noindex" />}
         {endpoints && (
           <>
             <meta


### PR DESCRIPTION
#### What is the purpose of this pull request?

try to stop category indexing to prevent `no-canonical/duplicate` errors by Google crawler

#### How should this be manually tested?

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
