### PR TITLE
fix(getdocspaths): do not fetch docs/release-notes paths for guides

### DIFF
--- a/src/components/last-updates-section/index.tsx
+++ b/src/components/last-updates-section/index.tsx
@@ -9,8 +9,8 @@ const lastReleaseNote: CardProps = {
   action: {
     type: 'info',
     description:
-      'Temporary freeze on automatic app distribution in preparation for Black Friday 2023',
-    date: new Date('11/17/2023'),
+      'A/B test information: maximum time for tests is now limited to 30 days',
+    date: new Date('12/13/2023'),
   },
   updateType: 'release-notes',
 }

--- a/src/pages/updates/release-notes/[slug].tsx
+++ b/src/pages/updates/release-notes/[slug].tsx
@@ -26,7 +26,7 @@ import { removeHTML } from 'utils/string-utils'
 import { flattenJSON, getKeyByValue, getParents } from 'utils/navigation-utils'
 import getNavigation from 'utils/getNavigation'
 import getGithubFile from 'utils/getGithubFile'
-import getDocsPaths from 'utils/getReleasePaths'
+import getReleasePaths from 'utils/getReleasePaths'
 import replaceMagicBlocks from 'utils/replaceMagicBlocks'
 import escapeCurlyBraces from 'utils/escapeCurlyBraces'
 import replaceHTMLBlocks from 'utils/replaceHTMLBlocks'
@@ -37,7 +37,7 @@ import styles from 'styles/documentation-page'
 import { PreviewContext } from 'utils/contexts/preview'
 import { remarkCodeHike } from '@code-hike/mdx'
 
-const docsPathsGLOBAL = await getDocsPaths()
+const docsPathsGLOBAL = await getReleasePaths()
 
 interface Props {
   content: string
@@ -123,7 +123,7 @@ const DocumentationPage: NextPage<Props> = ({ serialized, branch }) => {
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  // const slugs = Object.keys(await getDocsPaths())
+  // const slugs = Object.keys(await getReleasePaths())
   // const paths = slugs.map((slug) => ({
   //   params: { slug },
   // }))
@@ -148,7 +148,7 @@ export const getStaticProps: GetStaticProps = async ({
   const docsPaths =
     process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
       ? docsPathsGLOBAL
-      : await getDocsPaths(branch)
+      : await getReleasePaths(branch)
 
   const path = docsPaths[slug]
   if (!path) {

--- a/src/utils/getDocsPaths.ts
+++ b/src/utils/getDocsPaths.ts
@@ -24,7 +24,7 @@ export default async function getDocsPaths(branch = 'main') {
   repoTree.tree.map((node: any) => {
     const path = node.path
     const re = /^(?<path>.+\/)*(?<filename>.+)\.(?<filetype>.+)$/
-    if (path.startsWith('docs')) {
+    if (path.startsWith('docs') && !path.startsWith('docs/release-notes')) {
       const match = path.match(re)
       const filename = match?.groups?.filename ? match?.groups?.filename : ''
       const filetype = match?.groups?.filetype ? match?.groups?.filetype : ''


### PR DESCRIPTION
#### What is the purpose of this pull request?

Stop rendering Release Notes using the `docs/guides` route.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
