### PR TITLE
Update netlify.toml: Fixing docs redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,11 @@ included_files = ["node_modules/sharp/**/*", "./github.pem"]
 
 [[redirects]]
 force = true
+from = "/404/docs/recipes/style/using-css-handles-for-store-customization"
+status = 308
+to = "/docs/guides/vtex-io-documentation-using-css-handles-for-store-customization"
+[[redirects]]
+force = true
 from = "/docs/guides/vtexbr-buybox-context"
 status = 308
 to = "/docs/apps/vtexbr.buybox-context"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,12 @@ included_files = ["node_modules/sharp/**/*", "./github.pem"]
 
 [[redirects]]
 force = true
+from = "/docs/guides/vtexbr-buybox-context"
+status = 308
+to = "/docs/apps/vtexbr.buybox-context"
+
+[[redirects]]
+force = true
 from = "/docs/apps/vtex.store-icons/iconpack"
 status = 308
 to = "/docs/guides/vtex-store-icons-iconpack"


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR redirects the following docs:
-  path `/docs/guides/vtexbr-buybox-context` to the right one: `/docs/apps/vtexbr.buybox-context`. Reference: [EDU-9549](https://vtex-dev.atlassian.net/browse/EDU-9549)

- path `/404/docs/recipes/style/using-css-handles-for-store-customization` to the right one: `/docs/guides/vtex-io-documentation-using-css-handles-for-store-customization`.
Reference: [EDU-9923](https://vtex-dev.atlassian.net/browse/EDU-9923)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
