### PR TITLE
fix(apps): edit specifiedVersion checks

### DIFF
--- a/src/pages/docs/apps/[slug]/[child].tsx
+++ b/src/pages/docs/apps/[slug]/[child].tsx
@@ -187,9 +187,20 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     const appId = data.appId
     const latestVersion = data.latestVersion
     const currentVersion = data.currentVersion
-    const specifiedVersion = app.split('@')[1]
+    let specifiedVersion = app.split('@')[1]
       ? app.split('@')[1]
       : currentVersion
+
+    if (specifiedVersion.endsWith('.')) {
+      specifiedVersion += '0'
+    }
+    if (specifiedVersion.split('.').length === 1) {
+      specifiedVersion += '.0'
+    }
+    if (specifiedVersion.split('.').length === 2) {
+      specifiedVersion += '.0'
+    }
+
     const headingList: Item[] = []
     if (markdown) {
       {

--- a/src/pages/docs/apps/[slug]/index.tsx
+++ b/src/pages/docs/apps/[slug]/index.tsx
@@ -177,9 +177,20 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     let markdown = data.markdown
     const latestVersion = data.latestVersion
     const currentVersion = data.currentVersion
-    const specifiedVersion = app.split('@')[1]
+    let specifiedVersion = app.split('@')[1]
       ? app.split('@')[1]
       : currentVersion
+
+    if (specifiedVersion.endsWith('.')) {
+      specifiedVersion += '0'
+    }
+    if (specifiedVersion.split('.').length === 1) {
+      specifiedVersion += '.0'
+    }
+    if (specifiedVersion.split('.').length === 2) {
+      specifiedVersion += '.0'
+    }
+
     const childrenDocs = data.childrenDocs ?? ['']
     const headingList: Item[] = []
     const parentsArray: string[] = []


### PR DESCRIPTION
#### What is the purpose of this pull request?

Altered specifiedVersion to treat the following scenarios:
- Specified version without one or two `.0`: now appending `.0` when applicable before comparing to the current version (as reported in [EDU-11202](https://vtex-dev.atlassian.net/browse/EDU-11202))
- Specified version ends in `.`: now appending `0` when applicable before comparing to the current version.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage
![image (14)](https://github.com/vtexdocs/devportal/assets/77292838/8c812a20-672a-4516-a651-67ba9b04e1ee)
![image (13)](https://github.com/vtexdocs/devportal/assets/77292838/f679aa4b-1910-4ca4-8390-b845f5f8ec2b)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
