### PR TITLE
Fix: create Faststore doc redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,13 @@
 external_node_modules = ["sharp"]
 included_files = ["node_modules/sharp/**/*", "./github.pem"]
 
+
+[[redirects]]
+force = true
+from = "/docs/guides/faststore/docs-brandless"
+status = 308
+to = "/docs/guides/faststore/themes-brandless"
+
 [[redirects]]
 force = true
 from = "/404/docs/recipes/style/using-css-handles-for-store-customization"


### PR DESCRIPTION
#### What is the purpose of this pull request?

[This link](https://developers.vtex.com/docs/guides/faststore/docs-brandless) is broken, and it's showing in Google search results.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
