### PR TITLE
Update navigation.json: New doc - Mutiple page templates

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -13011,6 +13011,13 @@
                   "children": []
                 },
                 {
+                  "name": "Widgets for Headless CMS",
+                  "slug": "faststore/headless-cms-widgets",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
                   "name": "Troubleshooting",
                   "slug": "faststore/troubleshooting-error-installing-headless-cms",
                   "origin": "",

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -13011,13 +13011,6 @@
                   "children": []
                 },
                 {
-                  "name": "Widgets for Headless CMS",
-                  "slug": "faststore/headless-cms-widgets",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
                   "name": "Troubleshooting",
                   "slug": "faststore/troubleshooting-error-installing-headless-cms",
                   "origin": "",

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -13003,6 +13003,14 @@
                   "type": "markdown",
                   "children": []
                 },
+                ,
+                {
+                  "name": "Multiple page templates",
+                  "slug": "faststore/headless-cms-multiple-page-template",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
                 {
                   "name": "Troubleshooting",
                   "slug": "faststore/troubleshooting-error-installing-headless-cms",

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -13003,10 +13003,16 @@
                   "type": "markdown",
                   "children": []
                 },
-                ,
                 {
                   "name": "Multiple page templates",
                   "slug": "faststore/headless-cms-multiple-page-template",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
+                  "name": "Widgets for Headless CMS",
+                  "slug": "faststore/headless-cms-widgets",
                   "origin": "",
                   "type": "markdown",
                   "children": []


### PR DESCRIPTION
#### What is the purpose of this pull request?

It is related to the [#1043](https://github.com/vtexdocs/dev-portal-content/pull/1043)

This PR also adds the reference in the navigation to the [Widgets documentation](https://developers.vtex.com/docs/guides/faststore/headless-cms-widgets).

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
