### PR TITLE
Doc: Create redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1315,3 +1315,9 @@ force = true
 from = "/docs/guides/how-the-queries-in-master-data-v1-work"
 status = 308
 to = "/docs/guides/querying-documents-in-master-data-v1"
+
+[[redirects]]
+force = true
+from = "/docs/guides/using-the-docs-builder-to-publish-app-documentation"
+status = 308
+to = "/docs/guides/vtex-io-documentation-docs-builder"


### PR DESCRIPTION
Redirect from `/docs/guides/using-the-docs-builder-to-publish-app-documentation` to `/docs/guides/vtex-io-documentation-docs-builder`.
