### PR TITLE
Remove recurrence v1 api

### DIFF
--- a/src/pages/api/openapi/[slug].tsx
+++ b/src/pages/api/openapi/[slug].tsx
@@ -43,7 +43,6 @@ const referencePaths = objectFlip({
   'VTEX - Pricing Hub': 'pricing-hub',
   'VTEX - Profile System': 'profile-system',
   'VTEX - Promotions & Taxes API': 'promotions-and-taxes-api',
-  'VTEX - Recurrence (v1 - deprecated)': 'recurrence-v1-deprecated',
   'VTEX - Reviews and Ratings API': 'reviews-and-ratings-api',
   'VTEX - SKU Bindings API': 'sku-bindings-api',
   'VTEX - Search API': 'search-api',

--- a/src/utils/getReferencePaths.ts
+++ b/src/utils/getReferencePaths.ts
@@ -56,7 +56,6 @@ const fileSlugMap = {
   'VTEX - Pricing Hub': 'pricing-hub',
   'VTEX - Profile System': 'profile-system',
   'VTEX - Promotions & Taxes API': 'promotions-and-taxes-api',
-  'VTEX - Recurrence (v1 - deprecated)': 'recurrence-v1-deprecated',
   'VTEX - Reviews and Ratings API': 'reviews-and-ratings-api',
   'VTEX - SKU Bindings API': 'sku-bindings-api',
   'VTEX - Search API': 'search-api',


### PR DESCRIPTION
The Recurrence v1 API is deprecated and will be removed from openapi-schemas. There are no files registered in navigations, for the API was never published.

#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
