### PR TITLE
docs(navigation.json): routing category cover

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1410,3 +1410,9 @@ force = true
 from = "/docs/guides/vtex-io-documentation-cms"
 status = 308
 to = "/docs/guides/working-with-site-editor"
+
+[[redirects]]
+force = true
+from = "/docs/guides/vtex-io-documentation-routes"
+status = 308
+to = "/docs/guides/routing"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1415,4 +1415,4 @@ to = "/docs/guides/working-with-site-editor"
 force = true
 from = "/docs/guides/vtex-io-documentation-routes"
 status = 308
-to = "/docs/guides/routing"
+to = "/docs/guides/store-framework-routing"

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -14235,13 +14235,6 @@
                   "children": []
                 },
                 {
-                  "name": "Routes",
-                  "slug": "vtex-io-documentation-routes",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
                   "name": "Slots",
                   "slug": "vtex-io-documentation-slots",
                   "origin": "",
@@ -14617,9 +14610,9 @@
             },
             {
               "name": "Routing",
-              "slug": "store-framework-routing-category",
+              "slug": "routing",
               "origin": "",
-              "type": "category",
+              "type": "markdown",
               "children": [
                 {
                   "name": "Best practices for associating a custom page with a content type",

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -14610,7 +14610,7 @@
             },
             {
               "name": "Routing",
-              "slug": "routing",
+              "slug": "store-framework-routing",
               "origin": "",
               "type": "markdown",
               "children": [


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Excluded `routes` from sidebar
- Updated `routing` as a markdown doc
- Created redirect from `/docs/guides/vtex-io-documentation-routes` to `/docs/guides/store-framework-routing`

Refers to [#1371](https://github.com/vtexdocs/dev-portal-content/pull/1371)

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
