### PR TITLE
fix(api-reference/[slug].tsx): update SwaggerParser url

### DIFF
--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -203,9 +203,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   let api
   if (slugs.includes(slug as string)) {
     try {
-      api = await SwaggerParser.dereference(
-        `https://developers.vtex.com/api/openapi/${slug}`
-      )
+      api = await SwaggerParser.dereference(url)
     } catch (error) {
       logger.error(`Parse Error on file ${slug}`)
       return {


### PR DESCRIPTION
use openapi spec from cdn.jsdelivr (openapi master branch) instead of the spec url in production in the developer portal

#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
