### PR TITLE
Create redirect for archived Subscriptions v3 migration guide

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -99,6 +99,12 @@ to = "/docs/guides/order-canceling-improvements"
 
 [[redirects]]
 force = true
+from = "/docs/guides/subscriptions-v3-migration-guide"
+status = 308
+to = "/docs/guides/subscriptions"
+
+[[redirects]]
+force = true
 from = "/docs/api-reference/vtex-log-tracking-app"
 status = 308
 to = "/docs/api-reference/tracking"


### PR DESCRIPTION
Creating redirect because Subscriptions v2 is deprecated and the "Subscriptions v3 migration guide" article was removed.

#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
