### PR TITLE
Fix: redirecting API extensions troubleshooting doc

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,12 @@ included_files = ["node_modules/sharp/**/*", "./github.pem"]
 
 [[redirects]]
 force = true
+from = "/docs/guides/faststore/api-extensions-troubleshooting"
+status = 308
+to = "/docs/troubleshooting/issues-during-extending-the-faststore-api-schema"
+
+[[redirects]]
+force = true
 from = "/docs/guides/faststore/project-structure-updating-the-core-package-version"
 status = 308
 to = "/docs/guides/faststore/project-structure-updating-the-cli-package-version"

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -13828,13 +13828,6 @@
                       "children": []
                     }
                   ]
-                },
-                {
-                  "name": "Troubleshooting",
-                  "slug": "faststore/api-extensions-troubleshooting",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
                 }
               ]
             },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Redirecting the[ troubleshooting](https://developers.vtex.com/docs/guides/faststore/api-extensions-troubleshooting) to its new page and category: https://developers.vtex.com/docs/troubleshooting/issues-during-extending-the-faststore-api-schema

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
