### PR TITLE
refactor(api): update getReferencePaths to use internal API routes

### DIFF
--- a/src/utils/getReferencePaths.ts
+++ b/src/utils/getReferencePaths.ts
@@ -86,9 +86,9 @@ export default async function getReferencePaths(
             ? match?.groups?.filetype
             : ''
           if (filetype === 'json' || filetype === 'yaml') {
-            referencePaths[
-              fileSlugMap[filename] || filename
-            ] = `https://cdn.jsdelivr.net/gh/vtex/openapi-schemas/${path}`
+            // Use internal API route instead of jsDelivr
+            const slug = fileSlugMap[filename] || filename
+            referencePaths[slug] = `/api/openapi/${slug}`
           }
         }
       }


### PR DESCRIPTION
Replace jsDelivr URLs with internal API routes for better performance and reliability

#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
