### PR TITLE
Fix OpenAPI spec reference resolution in API reference documentation

### DIFF
--- a/src/pages/api/openapi/[slug].tsx
+++ b/src/pages/api/openapi/[slug].tsx
@@ -210,12 +210,13 @@ async function resolveReferences(
     // Parse the raw spec to get a JS object
     const parsedSpec = JSON.parse(spec)
 
-    // Use SwaggerParser to resolve all references
-    const resolvedSpec = await SwaggerParser.resolve(parsedSpec)
+    // Use SwaggerParser.bundle() instead of resolve() to properly handle references
+    // bundle() creates a spec with only internal references that's safe for serialization
+    const bundledSpec = await SwaggerParser.bundle(parsedSpec)
 
     // Convert back to string and indicate success
     return {
-      spec: JSON.stringify(resolvedSpec),
+      spec: JSON.stringify(bundledSpec),
       resolved: true,
     }
   } catch (error) {

--- a/src/pages/api/openapi/[slug].tsx
+++ b/src/pages/api/openapi/[slug].tsx
@@ -7,6 +7,7 @@ export const config = {
 import { githubConfig } from 'utils/github-config'
 import { getLogger } from 'utils/logging/log-util'
 import SwaggerParser from '@apidevtools/swagger-parser'
+import { NextApiRequest, NextApiResponse } from 'next'
 
 const logger = getLogger('openapi-endpoint')
 
@@ -68,10 +69,13 @@ const referencePaths = objectFlip({
   'VTEX - Audience API': 'audience-api',
 })
 
-function objectFlip(obj: { [x: string]: string }) {
-  return Object.keys(obj).reduce((ret, key) => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+// Type for reference paths mapping
+interface ReferencePathsMapping {
+  [key: string]: string
+}
+
+function objectFlip(obj: { [x: string]: string }): ReferencePathsMapping {
+  return Object.keys(obj).reduce((ret: ReferencePathsMapping, key) => {
     ret[obj[key]] = key
     return ret
   }, {})
@@ -233,11 +237,15 @@ async function resolveReferences(
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default async function handler(req: any, res: any) {
-  const { slug } = req.query
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+/**
+ * API handler for OpenAPI specifications
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const slugParam = req.query.slug
+  const slug = Array.isArray(slugParam) ? slugParam[0] : slugParam || ''
   const path = referencePaths[slug] || ''
 
   if (!path) {


### PR DESCRIPTION
This PR addresses issues with OpenAPI specification reference resolution in the API reference documentation pages.

### Key improvements:

- Enhanced server-side reference resolution using SwaggerParser.bundle() for better handling of external references
- Improved client-side fallback mechanism when server-side resolution fails
- Fixed RapiDoc component configuration to prevent null reference errors
- Added proper development environment support with localhost URLs
- Simplified error handling by consistently returning 404 for unparseable API specs
- Removed special case handling for problematic API specs for better maintainability

These changes make the API reference documentation more reliable and resilient when displaying complex OpenAPI specifications with external references.