### PR TITLE
Feat/netlify caching improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [About](#about)
   - [Objective](#objective)
   - [Concepts and Features](#concepts-and-features)
+  - [Caching Structure for Technical Writers](#caching-structure-for-technical-writers)
 - [Versioning](#versioning)
 - [Tests](#tests)
 - [Development](#development)
@@ -49,6 +50,43 @@ As the Developer Portal provides VTEX documentation to users, some of its main f
   - Configurable retry mechanism with max retries and timeout
   - Automatic fallback to raw.githubusercontent.com when API limits are hit
   - Smart throttling to prevent excessive API calls
+
+### Caching Structure for Technical Writers
+
+The Developer Portal uses Netlify's CDN and caching infrastructure to optimize performance. When updating documentation, technical writers should be aware of how caching affects the visibility of their changes:
+
+#### OpenAPI Documentation Caching
+
+When you update an OpenAPI specification file in the GitHub repository:
+
+1. **Cache Duration**: 
+   - Updated specs will be visible after the cache expires, typically:
+     - Primary source (jsdelivr): 5 minutes (300 seconds)
+     - Fallback source (GitHub raw): 3 minutes (180 seconds)
+   - A stale-while-revalidate period of up to 15 minutes may follow
+
+2. **Cache Invalidation Options**:
+   - **Automatic Expiration**: Wait for the cache to naturally expire (~5 minutes)
+   - **Manual Purging**: For urgent updates, you can request cache purging via Netlify's Cache Purge API using cache tags:
+     ```bash
+     curl -X POST "https://api.netlify.com/api/v1/sites/{site-id}/builds/cache" \
+       -H "Authorization: Bearer {access-token}" \
+       -H "Content-Type: application/json" \
+       -d '{"cache_tags": ["openapi,spec-name"]}'
+     ```
+
+3. **Debugging Cache Status**:
+   - The API response includes debugging headers to help track cache status:
+     - `X-Source`: Shows which source provided the spec (jsdelivr or github-raw)
+     - `X-References-Resolved`: Indicates if spec references were resolved
+     - `X-Cache-Debug`: Contains source, resolution status, and TTL information
+
+4. **Testing Updates**:
+   - To verify changes immediately without waiting for cache expiration:
+     - Add a unique query parameter to force a cache miss: `?v=timestamp`
+     - Request cache purging from your development team
+
+Understanding this caching structure helps set appropriate expectations for when documentation updates will become visible to users.
 
 ## Versioning
 

--- a/src/pages/api/openapi/[slug].tsx
+++ b/src/pages/api/openapi/[slug].tsx
@@ -286,7 +286,7 @@ export default async function handler(
   // Define more cache parameters
   const PRIMARY_TTL = Math.min(configuredMaxAge, 300) // Cap at 5 minutes
   const FALLBACK_TTL = Math.min(Math.floor(configuredMaxAge / 2), 180) // Cap at 3 minutes
-  const SWR_FACTOR = 10 // Reduce stale-while-revalidate multiplier from 24 to 10
+  const SWR_FACTOR = 3 // Reduce stale-while-revalidate multiplier from 24 to 3
 
   // Track successful response for returning
   let finalResult: FetchResult | null = null

--- a/src/pages/api/openapi/[slug].tsx
+++ b/src/pages/api/openapi/[slug].tsx
@@ -281,7 +281,11 @@ export default async function handler(
 
   // Get cache configuration from github-config
   const configuredMaxAge = githubConfig.cacheTTL || 3600
-  const staleWhileRevalidate = configuredMaxAge * 24
+
+  // Define more cache parameters
+  const PRIMARY_TTL = configuredMaxAge
+  const FALLBACK_TTL = Math.floor(configuredMaxAge / 2)
+  const SWR_FACTOR = 24 // stale-while-revalidate multiplier
 
   // Track successful response for returning
   let finalResult: FetchResult | null = null
@@ -361,13 +365,27 @@ export default async function handler(
         }`
       )
 
+      // Calculate TTL based on source (primary source gets longer TTL)
+      const ttl = finalResult.source === 'jsdelivr' ? PRIMARY_TTL : FALLBACK_TTL
+      const swr = ttl * SWR_FACTOR
+
       return res
         .setHeader(
-          'Cache-Control',
-          `public, s-maxage=${configuredMaxAge}, stale-while-revalidate=${staleWhileRevalidate}`
+          'Netlify-CDN-Cache-Control',
+          `public, s-maxage=${ttl}, stale-while-revalidate=${swr}, durable`
         )
+        .setHeader(
+          'Cache-Control',
+          `public, max-age=0, s-maxage=${ttl}, stale-while-revalidate=${swr}, must-revalidate`
+        )
+        .setHeader('Netlify-Cache-Tag', `openapi,${slug}`)
+        .setHeader('Vary', 'Accept')
         .setHeader('X-Source', finalResult.source)
         .setHeader('X-References-Resolved', resolvedResult.resolved.toString())
+        .setHeader(
+          'X-Cache-Debug',
+          `source=${finalResult.source},resolved=${resolvedResult.resolved},ttl=${ttl}`
+        )
         .send(resolvedResult.spec)
     }
 

--- a/src/pages/api/openapi/[slug].tsx
+++ b/src/pages/api/openapi/[slug].tsx
@@ -280,12 +280,13 @@ export default async function handler(
   }
 
   // Get cache configuration from github-config
-  const configuredMaxAge = githubConfig.cacheTTL || 3600
+  // If no TTL is configured, use 5 minutes (300 seconds) as default instead of 1 hour
+  const configuredMaxAge = githubConfig.cacheTTL || 300
 
   // Define more cache parameters
-  const PRIMARY_TTL = configuredMaxAge
-  const FALLBACK_TTL = Math.floor(configuredMaxAge / 2)
-  const SWR_FACTOR = 24 // stale-while-revalidate multiplier
+  const PRIMARY_TTL = Math.min(configuredMaxAge, 300) // Cap at 5 minutes
+  const FALLBACK_TTL = Math.min(Math.floor(configuredMaxAge / 2), 180) // Cap at 3 minutes
+  const SWR_FACTOR = 10 // Reduce stale-while-revalidate multiplier from 24 to 10
 
   // Track successful response for returning
   let finalResult: FetchResult | null = null


### PR DESCRIPTION
This pull request includes significant updates to the caching structure for technical writers and improvements to cache configuration in the API handler. The most important changes are outlined below:

### Documentation Updates:

* Added a new section to the `README.md` detailing the caching structure for technical writers, including cache duration, invalidation options, debugging cache status, and testing updates. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R8) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R54-R90)

### Cache Configuration Improvements:

* Updated the cache TTL configuration in `src/pages/api/openapi/[slug].tsx` to use a default of 5 minutes instead of 1 hour and introduced additional cache parameters for primary and fallback sources. ([src/pages/api/openapi/[slug].tsxL283-R289](diffhunk://#diff-42ffa6951a45dc7b24a41d1dd510e31584505ebef05f0052900f73d8d5328e77L283-R289))
* Modified the API response headers to include detailed cache control and debugging information, tailored to the source of the data (primary or fallback). ([src/pages/api/openapi/[slug].tsxR369-R389](diffhunk://#diff-42ffa6951a45dc7b24a41d1dd510e31584505ebef05f0052900f73d8d5328e77R369-R389))#### What is the purpose of this pull request?


