### PR TITLE
EDU-11170 - Fix origin's URL

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1827,6 +1827,6 @@ to = "/docs/app-development"
 
 [[redirects]]
 force = true
-from = "/docs/api-reference/dkim-configuration#createdkim"
+from = "/docs/api-reference/dkim-configuration"
 status = 308
 to = "/docs/api-reference/message-center-api"


### PR DESCRIPTION
#### What problem is this solving?

Fix origin's URL. Refers to [EDU-11170](https://vtex-dev.atlassian.net/browse/EDU-11170).

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
