### PR TITLE
update(netlify.toml): redirect store icons

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2340,3 +2340,9 @@ force = true
 from = "/docs/api-reference/storefront-permissions-api/*"
 status = 308
 to = "/docs/api-reference/storefront-roles-api/:splat"
+
+[[redirects]]
+force = true
+from = "/docs/guides/vtex-store-icons-iconpack"
+status = 308
+to = "/docs/apps/vtex.store-icons/iconpack"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Redirect from `docs/guides/vtex-store-icons-iconpack` to `docs/apps/vtex.store-icons/iconpack`.

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
