### PR TITLE
Add AI-Assisted Development category to navigation

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -2642,7 +2642,7 @@
            ]
          },
          {
-           "name": "AI-Assisted Development",
+           "name": "AI-assisted development",
            "slug": "ai-assisted-development-overview",
            "origin": "",
            "type": "markdown",

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -18111,6 +18111,21 @@
           "type": "category",
           "children": [
             {
+              "name": "April",
+              "slug": "april-2026",
+              "origin": "",
+              "type": "category",
+              "children": [
+                {
+                  "name": "Introducing VTEX Developer MCP and Skills for AI-assisted development",
+                  "slug": "2026-04-09-vtex-developer-mcp-and-skills",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                }
+              ]
+            },
+            {
               "name": "March",
               "slug": "march-2026",
               "origin": "",


### PR DESCRIPTION
## Summary

Adds a new **AI-Assisted Development** category to the Guides navigation with two entries:

- **VTEX Developer MCP** — `vtex-developer-mcp`
- **VTEX Skills** — `vtex-skills`

## Related

- Content PR: vtexdocs/dev-portal-content#2589 (guides)
- Release note PR: vtexdocs/dev-portal-content#2590