### PR TITLE
EDU-16867 - Add payment data release note to navigation

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -18329,6 +18329,21 @@
           "type": "category",
           "children": [
             {
+              "name": "May",
+              "slug": "may-2026",
+              "origin": "",
+              "type": "category",
+              "children": [
+                {
+                  "name": "Marketplace payment data can now be shared with sellers",
+                  "slug": "2026-05-01-marketplace-payment-data-can-now-be-shared-with-sellers",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                }
+              ]
+            },
+            {
               "name": "April",
               "slug": "april-2026",
               "origin": "",

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -18412,7 +18412,12 @@
               "children": [
                 {
                   "name": "Marketplace payment data can now be shared with sellers",
-                  "slug": "2026-05-01-marketplace-payment-data-can-now-be-shared-with-sellers",
+                  "slug": "2026-05-08-marketplace-payment-data-can-now-be-shared-with-sellers",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
                   "name": "FastStore v4: New major version with performance, localization, and architectural updates",
                   "slug": "2026-05-05-faststore-v4",
                   "origin": "",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add May category and release note about payment data for marketplace and sellers to `navigation.json`. Refers to [EDU-16867](https://vtex-dev.atlassian.net/browse/EDU-16867).

> Must be merged with the [release note PR](https://github.com/vtexdocs/dev-portal-content/pull/2617).

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
