### PR TITLE
Remove redirect for vtex.store-icons/iconpack

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -309,12 +309,6 @@ to = "/docs/apps/vtexbr.buybox-context"
 
 [[redirects]]
 force = true
-from = "/docs/apps/vtex.store-icons/iconpack"
-status = 308
-to = "/docs/guides/vtex-store-icons-iconpack"
-
-[[redirects]]
-force = true
 from = "/docs/api-reference/freight-values"
 status = 308
 to = "/docs/api-reference/logistics-api#post-/api/logistics/pvt/configuration/freights/-carrierId-/values/update"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove redirect for vtex.store-icons/iconpack

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
