### PR TITLE
EDU-18225 - Add custom data release note to navigation

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -18411,6 +18411,13 @@
               "type": "category",
               "children": [
                 {
+                  "name": "Orders: Custom data now visible in the VTEX Admin",
+                  "slug": "2026-05-08-orders-custom-data-now-visible-in-the-vtex-admin",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
                   "name": "Marketplace payment data can now be shared with sellers",
                   "slug": "2026-05-08-marketplace-payment-data-can-now-be-shared-with-sellers",
                   "origin": "",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add release note about custom data visibility to `navigation.json`. Refers to [EDU-18225](https://vtex-dev.atlassian.net/browse/EDU-18225).

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
