### PR TITLE
EDU-15450: add User Rights API to openapi slug mapping

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -500,4 +500,5 @@ export const openapiMappings: { [key: string]: string } = {
   'VTEX - B2B Buyer Data API': 'b2b-buyer-data-api',
   'VTEX - B2B Addresses API': 'b2b-addresses',
   'VTEX - B2B Contracts API': 'b2b-contracts-api',
+  'VTEX - User Rights API': 'user-rights-api',
 }


### PR DESCRIPTION
Adds a slug mapping entry for the new User Rights API spec, recently introduced in the `vtex/openapi-schemas` repo via [PR #1630](https://github.com/vtex/openapi-schemas/pull/1630).

## Related Task

[EDU-15450](https://vtex-dev.atlassian.net/browse/EDU-15450)
