### PR TITLE
EDU-16758: fix API reference endpoint deep links rendering as overview

### DIFF
--- a/src/pages/docs/api-reference/[slug].tsx
+++ b/src/pages/docs/api-reference/[slug].tsx
@@ -192,14 +192,26 @@ const APIPage: NextPage<Props> = ({
   const pageTitle =
     capitalize(slug.replaceAll('-', ' ').replace('api', '')) + ' API'
 
-  // Derive the active endpoint identifier from the current Next route. Hash
-  // navigation pushes the URL back through `router.push` (see effects below),
-  // so `router.asPath` stays in sync with `window.location` and this stays
-  // truthful on every render.
-  const hasHashTag = router.asPath.indexOf('#') > -1
-  const cleanPath = hasHashTag
-    ? router.asPath.split('#')[1]
-    : router.asPath.split('?endpoint=')[1] || ''
+  // Track the URL hash from `window.location` directly. `router.asPath` does
+  // not include the hash on SSR or on the initial client hydration of a
+  // directly-loaded URL, so relying on it alone would force the overview view
+  // for every deep link like `/docs/api-reference/foo#get--endpoint`.
+  const [clientHash, setClientHash] = useState('')
+
+  useEffect(() => {
+    const syncHash = () =>
+      setClientHash(decodeURIComponent(window.location.hash.slice(1)))
+
+    syncHash()
+    window.addEventListener('hashchange', syncHash)
+    return () => window.removeEventListener('hashchange', syncHash)
+  }, [])
+
+  const routerHash =
+    router.asPath.indexOf('#') > -1
+      ? router.asPath.split('#')[1]
+      : router.asPath.split('?endpoint=')[1] || ''
+  const cleanPath = clientHash || routerHash
 
   const getMethod = () => {
     const method = cleanPath.split('/')[0].replace('-', '').toUpperCase()


### PR DESCRIPTION
Fixes a regression introduced by PR #1226 (`feat/api-reference-seo-indexing`) where every deep link to an API reference endpoint — e.g. `/docs/api-reference/foo#get--endpoint` — rendered the overview page instead of the interactive RapiDoc endpoint view.

## Changes

- Track the URL hash via a `clientHash` state populated from `window.location.hash` on mount and on `hashchange`, replacing the previous `router.asPath`-only detection.
- Fall back to the existing `router.asPath` parsing when the client hash is empty, preserving the legacy `?endpoint=` behavior.

## Why

The SEO indexing PR introduced conditional rendering between the SSR-friendly overview HTML and the client-only RapiDoc element, gated by `isOverview = endpointPath === slug`. That flag was derived from `router.asPath`, but Next.js does not include the URL hash in `asPath` during SSR or on the initial client hydration of a directly-loaded URL. As a result, any direct link with a hash hydrated as the overview and never re-rendered into the endpoint view. Reading `window.location.hash` after mount restores the previous behavior without changing the SSR output.

## Notes

- SSR output is unchanged: `useState('')` produces the same overview HTML the server already rendered, so the SEO improvements from #1226 are preserved.
- In-page table clicks and back/forward navigation still work via the existing `hashchange` listener, which now also feeds `clientHash`.

## Related Task

[EDU-16758](https://vtex-dev.atlassian.net/browse/EDU-16758)
