### PR TITLE
feat(navigation.json): add B2B Buyer Portal Master Data architecture guide

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -2060,6 +2060,13 @@
                   "origin": "",
                   "type": "markdown",
                   "children": []
+                },
+                {
+                  "name": "B2B Buyer Portal Master Data architecture",
+                  "slug": "b2b-buyer-portal-master-data-architecture",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
                 }
               ]
             },
@@ -2184,7 +2191,7 @@
                   "origin": "",
                   "type": "markdown",
                   "children": []
-                }                
+                }
               ]
             },
             {
@@ -2810,32 +2817,32 @@
               "type": "markdown",
               "children": []
             }
-           ]
-         },
-         {
-           "name": "AI-assisted development",
-           "slug": "ai-assisted-development-overview",
-           "origin": "",
-           "type": "markdown",
-           "children": [
-             {
-               "name": "VTEX Developer MCP",
-               "slug": "vtex-developer-mcp",
-               "origin": "",
-               "type": "markdown",
-               "children": []
-             },
-             {
-               "name": "VTEX Skills",
-               "slug": "vtex-skills",
-               "origin": "",
-               "type": "markdown",
-               "children": []
-             }
-           ]
-         },
-         {
-           "name": "VTEX CX Platform (Weni)",
+          ]
+        },
+        {
+          "name": "AI-assisted development",
+          "slug": "ai-assisted-development-overview",
+          "origin": "",
+          "type": "markdown",
+          "children": [
+            {
+              "name": "VTEX Developer MCP",
+              "slug": "vtex-developer-mcp",
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": "VTEX Skills",
+              "slug": "vtex-skills",
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            }
+          ]
+        },
+        {
+          "name": "VTEX CX Platform (Weni)",
           "slug": "weni-by-vtex",
           "origin": "",
           "type": "category",
@@ -15067,7 +15074,6 @@
                   "origin": "",
                   "type": "markdown",
                   "children": []
-
                 }
               ]
             },
@@ -15276,7 +15282,7 @@
                   "type": "markdown",
                   "children": []
                 },
-                { 
+                {
                   "name": "Personal Shopper",
                   "slug": "apps/vtexventures.personal-shopper-free",
                   "origin": "",
@@ -18772,7 +18778,7 @@
                   "type": "markdown",
                   "children": []
                 },
-                                {
+                {
                   "name": "Orders: Custom data now visible in the VTEX Admin",
                   "slug": "2026-05-08-orders-custom-data-now-visible-in-the-vtex-admin",
                   "origin": "",
@@ -18947,7 +18953,7 @@
               ]
             }
           ]
-        }, 
+        },
         {
           "name": "2025",
           "slug": "2025-category",


### PR DESCRIPTION
Adds navigation entry for the B2B Buyer Portal Master Data architecture guide, introduced in [dev-portal-content#2702](https://github.com/vtexdocs/dev-portal-content/pull/2702).

## Related Task

[EDU-17995](https://vtex-dev.atlassian.net/browse/EDU-17995)