### PR TITLE
EDU-18555: add Audiences group to VTEX Ads API sidebar

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -13339,6 +13339,23 @@
               ]
             },
             {
+              "name": "Audiences",
+              "slug": "vtex-ads-api-audiences",
+              "origin": "",
+              "type": "category",
+              "children": [
+                {
+                  "name": "Generate audience upload URL",
+                  "slug": "vtex-ads-api",
+                  "type": "openapi",
+                  "method": "POST",
+                  "origin": "",
+                  "endpoint": "/audience/upload-url",
+                  "children": []
+                }
+              ]
+            },
+            {
               "name": "Ads events notification",
               "slug": "vtex-ads-api-events-notification",
               "type": "category",


### PR DESCRIPTION
## Summary

Adds the **Audiences** tag group and **Generate audience upload URL** endpoint to the VTEX Ads API sidebar navigation, matching the OpenAPI spec merged in [vtex/openapi-schemas#1718](https://github.com/vtex/openapi-schemas/pull/1718).

## Changes

- Add **Audiences** category under VTEX Ads API (after Catalog synchronization, matching OpenAPI tag order)
- Add **Generate audience upload URL** endpoint (`POST /audience/upload-url`)

## Why

The Ads API spec now includes a new Audiences tag with the upload URL endpoint. The Developers Portal sidebar must reflect this so the endpoint appears in the API Reference navigation.

## Related Task

[EDU-18555](https://vtex-dev.atlassian.net/browse/EDU-18555)
