### PR TITLE
docs: add Integrating audiences nav entry for VTEX Ads

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -2634,6 +2634,13 @@
                       "children": []
                     },
                     {
+                      "name": "Integrating audiences",
+                      "slug": "integrating-audiences",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
                       "name": "Digital Signage",
                       "slug": "digital-signage",
                       "origin": "",


### PR DESCRIPTION
Add the new `Integrating audiences` guide to the VTEX Ads sidebar navigation.

