### PR TITLE
chore: add custom-storefront-roles-and-resources nav and missing Storefront Roles API endpoints

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -2084,6 +2084,13 @@
                   "children": []
                 },
                 {
+                  "name": "Custom Storefront Roles and Resources",
+                  "slug": "custom-storefront-roles-and-resources",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
                   "name": "B2B Buyer Portal Master Data architecture",
                   "slug": "b2b-buyer-portal-master-data-architecture",
                   "origin": "",
@@ -13132,6 +13139,92 @@
                   "method": "GET",
                   "origin": "",
                   "endpoint": "/api/license-manager/storefront/users/-userId-",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": "Custom Storefront Roles",
+              "slug": "storefront-roles-api-custom-roles-category",
+              "type": "category",
+              "children": [
+                {
+                  "name": "List storefront roles",
+                  "slug": "storefront-roles-api",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/api/license-manager/storefront/role",
+                  "children": []
+                },
+                {
+                  "name": "Create storefront role",
+                  "slug": "storefront-roles-api",
+                  "type": "openapi",
+                  "method": "POST",
+                  "origin": "",
+                  "endpoint": "/api/license-manager/storefront/role",
+                  "children": []
+                },
+                {
+                  "name": "Fetch storefront role by ID",
+                  "slug": "storefront-roles-api",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/api/license-manager/storefront/role/-roleId-",
+                  "children": []
+                },
+                {
+                  "name": "Edit storefront role resources",
+                  "slug": "storefront-roles-api",
+                  "type": "openapi",
+                  "method": "PUT",
+                  "origin": "",
+                  "endpoint": "/api/license-manager/storefront/role/-roleId-",
+                  "children": []
+                },
+                {
+                  "name": "Delete storefront role",
+                  "slug": "storefront-roles-api",
+                  "type": "openapi",
+                  "method": "DELETE",
+                  "origin": "",
+                  "endpoint": "/api/license-manager/storefront/role/-roleId-",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": "Custom Storefront Resources",
+              "slug": "storefront-roles-api-custom-resources-category",
+              "type": "category",
+              "children": [
+                {
+                  "name": "List storefront resources",
+                  "slug": "storefront-roles-api",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/api/license-manager/storefront/resource",
+                  "children": []
+                },
+                {
+                  "name": "Create custom storefront resource",
+                  "slug": "storefront-roles-api",
+                  "type": "openapi",
+                  "method": "POST",
+                  "origin": "",
+                  "endpoint": "/api/license-manager/storefront/resource",
+                  "children": []
+                },
+                {
+                  "name": "Delete custom storefront resource",
+                  "slug": "storefront-roles-api",
+                  "type": "openapi",
+                  "method": "DELETE",
+                  "origin": "",
+                  "endpoint": "/api/license-manager/storefront/resource/-id-",
                   "children": []
                 }
               ]


### PR DESCRIPTION
- Added **Custom storefront roles and resources** guide in the B2B Buyer Portal navigation section, right after the existing Storefront Roles entry (introduced by https://github.com/vtexdocs/dev-portal-content/pull/2740)
- Added **8 missing endpoints** to the Storefront Roles API navigation, introduced by https://github.com/vtex/openapi-schemas/pull/1720:

  **Custom Storefront Roles** (new category):
  - `GET /api/license-manager/storefront/role` — List storefront roles
  - `POST /api/license-manager/storefront/role` — Create storefront role
  - `GET /api/license-manager/storefront/role/-roleId-` — Fetch storefront role by ID
  - `PUT /api/license-manager/storefront/role/-roleId-` — Edit storefront role resources
  - `DELETE /api/license-manager/storefront/role/-roleId-` — Delete storefront role

  **Custom Storefront Resources** (new category):
  - `GET /api/license-manager/storefront/resource` — List storefront resources
  - `POST /api/license-manager/storefront/resource` — Create custom storefront resource
  - `DELETE /api/license-manager/storefront/resource/-id-` — Delete custom storefront resource