### PR TITLE
docs: add VTEX Ads guide entries to Developers Portal navigation

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -2653,6 +2653,13 @@
                       "origin": "",
                       "type": "markdown",
                       "children": []
+                    },
+                    {
+                      "name": "Placement naming conventions",
+                      "slug": "placement-naming-conventions",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
                     }
                   ]
                 },
@@ -2703,8 +2710,22 @@
                       "origin": "",
                       "type": "markdown",
                       "children": []
+                    },
+                    {
+                      "name": "VTEX Ads Script Agent",
+                      "slug": "vtex-ads-script-agent",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
                     }
                   ]
+                },
+                {
+                  "name": "VTEX Ads best practices",
+                  "slug": "vtex-ads-best-practices",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
                 }
               ]
             },
@@ -2753,6 +2774,57 @@
                 {
                   "name": "VTEX Ads React Package Quickstart",
                   "slug": "vtex-ads-react-package-quickstart",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": "Exporting data from VTEX Ads",
+              "slug": "exporting-data-from-vtex-ads",
+              "origin": "",
+              "type": "markdown",
+              "children": [
+                {
+                  "name": "Exporting ads events",
+                  "slug": "exporting-ads-events",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
+                  "name": "Exporting ads reports",
+                  "slug": "exporting-ads-reports",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
+                  "name": "Exporting aggregated data from VTEX Ads",
+                  "slug": "exporting-aggregated-data-from-vtex-ads",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": "Integrating VTEX Ads with external marketplaces",
+              "slug": "integrating-vtex-ads-with-external-marketplaces",
+              "origin": "",
+              "type": "markdown",
+              "children": [
+                {
+                  "name": "Transferring credit",
+                  "slug": "transferring-credit",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
+                  "name": "VTEX Ads Single Sign On (SSO)",
+                  "slug": "vtex-ads-single-sign-on-sso",
                   "origin": "",
                   "type": "markdown",
                   "children": []


### PR DESCRIPTION
## Summary

Adds Developers Portal sidebar navigation entries for the VTEX Ads guides migrated and merged as single-file PRs split out from [dev-portal-content#2227](https://github.com/vtexdocs/dev-portal-content/pull/2227) (*VTEX Ads docs migration - part II*).

## Changes

Ten new entries under **Guides → VTEX Ads** in `public/navigation.json`:

- `Exporting data from VTEX Ads` (`exporting-data-from-vtex-ads`)
  - `Exporting ads events` (`exporting-ads-events`)
  - `Exporting ads reports` (`exporting-ads-reports`)
  - `Exporting aggregated data from VTEX Ads` (`exporting-aggregated-data-from-vtex-ads`)
- `Getting started with VTEX Ads API`
  - `Ads events` → `VTEX Ads Script Agent` (`vtex-ads-script-agent`)
  - `Retrieving ads` → `Placement naming conventions` (`placement-naming-conventions`)
  - `VTEX Ads best practices` (`vtex-ads-best-practices`)
- `Integrating VTEX Ads with external marketplaces` (`integrating-vtex-ads-with-external-marketplaces`)
  - `Transferring credit` (`transferring-credit`)
  - `VTEX Ads Single Sign On (SSO)` (`vtex-ads-single-sign-on-sso`)

## Why

The merged content PRs added the article files but the corresponding sidebar entries were missing (flagged in #2227's preview comment). These entries make the published guides reachable from the navigation. Each nav `slug` matches the article's frontmatter `slug`.

## Related Tasks

- [EDU-15231](https://vtex-dev.atlassian.net/browse/EDU-15231) — Exporting data from VTEX Ads
- [EDU-15233](https://vtex-dev.atlassian.net/browse/EDU-15233) — Exporting ads events
- [EDU-15234](https://vtex-dev.atlassian.net/browse/EDU-15234) — Exporting ads reports
- [EDU-15232](https://vtex-dev.atlassian.net/browse/EDU-15232) — Exporting aggregated data from VTEX Ads
- [EDU-15219](https://vtex-dev.atlassian.net/browse/EDU-15219) — VTEX Ads Script Agent
- [EDU-15218](https://vtex-dev.atlassian.net/browse/EDU-15218) — Placement naming conventions
- [EDU-15217](https://vtex-dev.atlassian.net/browse/EDU-15217) — VTEX Ads best practices
- [EDU-15221](https://vtex-dev.atlassian.net/browse/EDU-15221) — Integrating VTEX Ads with external marketplaces
- [EDU-15223](https://vtex-dev.atlassian.net/browse/EDU-15223) — Transferring credit
- [EDU-15224](https://vtex-dev.atlassian.net/browse/EDU-15224) — VTEX Ads Single Sign On (SSO)
