### PR TITLE
feat: add Intelligent Search API v1 navigation

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -8231,6 +8231,24 @@
                   "origin": "",
                   "endpoint": "/facets/-facets-",
                   "children": []
+                },
+                {
+                  "name": "Get attempt of correction of a misspelled term (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/correction-search",
+                  "children": []
+                },
+                {
+                  "name": "Get list of banners registered for query (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/banners/-facets-",
+                  "children": []
                 }
               ]
             },
@@ -8280,24 +8298,6 @@
                   "method": "GET",
                   "origin": "",
                   "endpoint": "/search-suggestions",
-                  "children": []
-                },
-                {
-                  "name": "Get attempt of correction of a misspelled term (v1)",
-                  "slug": "intelligent-search-api-v1",
-                  "type": "openapi",
-                  "method": "GET",
-                  "origin": "",
-                  "endpoint": "/correction-search",
-                  "children": []
-                },
-                {
-                  "name": "Get list of banners registered for query (v1)",
-                  "slug": "intelligent-search-api-v1",
-                  "type": "openapi",
-                  "method": "GET",
-                  "origin": "",
-                  "endpoint": "/banners/-facets-",
                   "children": []
                 }
               ]

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -8210,62 +8210,10 @@
           "type": "openapi",
           "children": [
             {
-              "name": "Autocomplete",
-              "slug": "intelligent-search-api-v1-autocomplete",
-              "type": "category",
-              "children": [
-                {
-                  "name": "Get list of the 10 most searched terms (v1)",
-                  "slug": "intelligent-search-api-v1",
-                  "type": "openapi",
-                  "method": "GET",
-                  "origin": "",
-                  "endpoint": "/top-searches",
-                  "children": []
-                },
-                {
-                  "name": "Get list of suggested terms and attributes similar to the search term (v1)",
-                  "slug": "intelligent-search-api-v1",
-                  "type": "openapi",
-                  "method": "GET",
-                  "origin": "",
-                  "endpoint": "/autocomplete-suggestions",
-                  "children": []
-                },
-                {
-                  "name": "Get list of suggested terms similar to the search term (v1)",
-                  "slug": "intelligent-search-api-v1",
-                  "type": "openapi",
-                  "method": "GET",
-                  "origin": "",
-                  "endpoint": "/search-suggestions",
-                  "children": []
-                }
-              ]
-            },
-            {
               "name": "Product List Page",
               "slug": "intelligent-search-api-v1-product-list-page",
               "type": "category",
               "children": [
-                {
-                  "name": "Get attempt of correction of a misspelled term (v1)",
-                  "slug": "intelligent-search-api-v1",
-                  "type": "openapi",
-                  "method": "GET",
-                  "origin": "",
-                  "endpoint": "/correction-search",
-                  "children": []
-                },
-                {
-                  "name": "Get list of banners registered for query (v1)",
-                  "slug": "intelligent-search-api-v1",
-                  "type": "openapi",
-                  "method": "GET",
-                  "origin": "",
-                  "endpoint": "/banners/-facets-",
-                  "children": []
-                },
                 {
                   "name": "Search products (v1)",
                   "slug": "intelligent-search-api-v1",
@@ -8298,6 +8246,58 @@
                   "method": "GET",
                   "origin": "",
                   "endpoint": "/products",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": "Autocomplete",
+              "slug": "intelligent-search-api-v1-autocomplete",
+              "type": "category",
+              "children": [
+                {
+                  "name": "Get list of the 10 most searched terms (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/top-searches",
+                  "children": []
+                },
+                {
+                  "name": "Get list of suggested terms and attributes similar to the search term (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/autocomplete-suggestions",
+                  "children": []
+                },
+                {
+                  "name": "Get list of suggested terms similar to the search term (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/search-suggestions",
+                  "children": []
+                },
+                {
+                  "name": "Get attempt of correction of a misspelled term (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/correction-search",
+                  "children": []
+                },
+                {
+                  "name": "Get list of banners registered for query (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/banners/-facets-",
                   "children": []
                 }
               ]

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -8204,6 +8204,123 @@
           ]
         },
         {
+          "name": "Intelligent Search API v1",
+          "slug": "intelligent-search-api-v1",
+          "origin": "",
+          "type": "openapi",
+          "children": [
+            {
+              "name": "Autocomplete",
+              "slug": "intelligent-search-api-v1-autocomplete",
+              "type": "category",
+              "children": [
+                {
+                  "name": "Get list of the 10 most searched terms (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/top-searches",
+                  "children": []
+                },
+                {
+                  "name": "Get list of suggested terms and attributes similar to the search term (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/autocomplete-suggestions",
+                  "children": []
+                },
+                {
+                  "name": "Get list of suggested terms similar to the search term (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/search-suggestions",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": "Product List Page",
+              "slug": "intelligent-search-api-v1-product-list-page",
+              "type": "category",
+              "children": [
+                {
+                  "name": "Get attempt of correction of a misspelled term (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/correction-search",
+                  "children": []
+                },
+                {
+                  "name": "Get list of banners registered for query (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/banners/-facets-",
+                  "children": []
+                },
+                {
+                  "name": "Search products (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/product-search/-facets-",
+                  "children": []
+                },
+                {
+                  "name": "List filters for a search (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/facets/-facets-",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": "Product Detail Page",
+              "slug": "intelligent-search-api-v1-product-detail-page",
+              "type": "category",
+              "children": [
+                {
+                  "name": "Get product (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/products",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": "Delivery Promise",
+              "slug": "intelligent-search-api-v1-delivery-promise",
+              "type": "category",
+              "children": [
+                {
+                  "name": "Get pickup point availability for Delivery Promise (v1)",
+                  "slug": "intelligent-search-api-v1",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/pickup-point-availability/-facets-",
+                  "children": []
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "Intelligent Search Events API - Headless",
           "slug": "intelligent-search-events-api-headless",
           "origin": "",

--- a/src/pages/docs/api-reference/index.tsx
+++ b/src/pages/docs/api-reference/index.tsx
@@ -87,13 +87,6 @@ const whatsNextData: WhatsNextDataElement[] = [
     linkTo: '/docs/api-reference/headless-cms-api',
   },
   {
-    title: 'Intelligent Search API',
-    description:
-      'Assist your customers in their purchase journey, presenting results from search bar interactions.',
-    linkTitle: 'See more',
-    linkTo: '/docs/api-reference/intelligent-search-api',
-  },
-  {
     title: 'Intelligent Search API v1',
     description:
       'New version of the Intelligent Search API with HTTP caching, lower latency, and explicit context parameters for headless integrations.',

--- a/src/pages/docs/api-reference/index.tsx
+++ b/src/pages/docs/api-reference/index.tsx
@@ -94,6 +94,13 @@ const whatsNextData: WhatsNextDataElement[] = [
     linkTo: '/docs/api-reference/intelligent-search-api',
   },
   {
+    title: 'Intelligent Search API v1',
+    description:
+      'New version of the Intelligent Search API with HTTP caching, lower latency, and explicit context parameters for headless integrations.',
+    linkTitle: 'See more',
+    linkTo: '/docs/api-reference/intelligent-search-api-v1',
+  },
+  {
     title: 'License Manager API',
     description:
       'Manage users, roles, hosts, AppKeys and AppTokens from a VTEX store.',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -442,6 +442,7 @@ export const openapiMappings: { [key: string]: string } = {
   'VTEX - Giftcard Provider Protocol': 'giftcard-provider-protocol',
   'VTEX - Headless CMS API': 'headless-cms-api',
   'VTEX - Intelligent Search API': 'intelligent-search-api',
+  'VTEX - Intelligent Search API - v1': 'intelligent-search-api-v1',
   'VTEX - License Manager API': 'license-manager-api',
   'VTEX - Logistics API': 'logistics-api',
   'VTEX - Marketplace APIs': 'marketplace-apis',


### PR DESCRIPTION
[EDU-18782](https://vtex-dev.atlassian.net/browse/EDU-18782)

> ⚠️ This PR should only be merged after [Intelligent Search API v1 reference](https://github.com/vtex/openapi-schemas/pull/1731) is merged in openapi-schemas.

Adds navigation entries for the new Intelligent Search API v1.

## Summary

- Added `'VTEX - Intelligent Search API - v1': 'intelligent-search-api-v1'` slug mapping to `constants.ts`
- Removed legacy Intelligent Search API card from the API reference index page
- Added Intelligent Search API v1 card to the API reference index page
- Added `navigation.json` entries for all 9 v1 endpoints, organized into 4 categories:
  - **Autocomplete:** Get list of the 10 most searched terms, Get list of suggested terms and attributes similar to the search term, Get list of suggested terms similar to the search term
  - **Product List Page:** Get attempt of correction of a misspelled term, Get list of banners registered for query, Search products, List filters for a search
  - **Product Detail Page:** Get product
  - **Delivery Promise:** Get pickup point availability for Delivery Promise

## Related

- [Intelligent Search API v1 reference](https://github.com/vtex/openapi-schemas/pull/1731) ← merge first
- [Release note](https://github.com/vtexdocs/dev-portal-content/pull/2773)
- [Migration guide](https://github.com/vtexdocs/dev-portal-content/pull/2774)