### PR TITLE
chore: add temp/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ RapiDoc
 
 # Planning docs (versioned separately)
 /plans
+
+# Temporary files
+/temp


### PR DESCRIPTION
Add the `temp/` directory to `.gitignore` so temporary working files are no longer tracked by git.
