### PR TITLE
feat(netlify.toml): add redirect for faststore getting started guide

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2418,3 +2418,9 @@ force = true
 from = "/docs/guides/assembly-options-app"
 status = 308
 to = "/docs/apps/vtex.admin-assembly-options"
+
+[[redirects]]
+force = true
+from = "/docs/guides/faststore/getting-started-faststore-v1-to-v3"
+status = 308
+to = "/docs/guides/faststore/getting-started-faststore-v1-to-v4"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add redirect for faststore migration guide: from `/docs/guides/faststore/getting-started-faststore-v1-to-v3` to `/docs/guides/faststore/getting-started-faststore-v1-to-v4`.

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
