### PR TITLE
fix: update authenticator routes to v1 in navigation

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -12944,7 +12944,7 @@
                   "type": "openapi",
                   "method": "POST",
                   "origin": "",
-                  "endpoint": "/api/authenticator/punchout/start",
+                  "endpoint": "/api/authenticator/v1/punchout/start",
                   "children": []
                 },
                 {
@@ -12953,7 +12953,7 @@
                   "type": "openapi",
                   "method": "POST",
                   "origin": "",
-                  "endpoint": "/api/authenticator/punchout/authenticated/start",
+                  "endpoint": "/api/authenticator/v1/punchout/authenticated/start",
                   "children": []
                 },
                 {
@@ -12962,7 +12962,7 @@
                   "type": "openapi",
                   "method": "GET",
                   "origin": "",
-                  "endpoint": "/api/authenticator/punchout/finish",
+                  "endpoint": "/api/authenticator/v1/punchout/finish",
                   "children": []
                 }
               ]
@@ -14360,7 +14360,7 @@
                   "type": "openapi",
                   "method": "POST",
                   "origin": "",
-                  "endpoint": "/api/authenticator/storefront/users",
+                  "endpoint": "/api/authenticator/v1/storefront/users",
                   "children": []
                 },
                 {


### PR DESCRIPTION
## Summary
- Updates 4 `endpoint` entries in `public/navigation.json` from `/api/authenticator/...` to `/api/authenticator/v1/...`, matching the API versioning rollout.
- Relates to https://github.com/vtex/openapi-schemas/pull/1741

## Test plan
- [x] Verified `public/navigation.json` still parses as valid JSON
- [x] Confirmed the 4 changed endpoints match the routes renamed in openapi-schemas#1741 (punchout start, punchout authenticated start, punchout finish, storefront users)
- [x] Confirmed `tenants/features/{name}` entries were already on `v1` and needed no change