### PR TITLE
Remove 'Getting started with VTEX IO' from navigation

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -2126,13 +2126,6 @@
               "type": "markdown",
               "children": [
                 {
-                  "name": "Getting started with VTEX IO for VTEX Shipping Network",
-                  "slug": "getting-started-with-vtex-io-for-vtex-shipping-network",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
                   "name": "Integration flow",
                   "slug": "integration-flow",
                   "origin": "",


### PR DESCRIPTION
Removed 'Getting started with VTEX IO for VTEX Shipping Network' section from navigation.

#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
