### PR TITLE
feat: add Authenticator API to navigation, mappings, and redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2424,3 +2424,27 @@ force = true
 from = "/docs/guides/faststore/getting-started-faststore-v1-to-v3"
 status = 308
 to = "/docs/guides/faststore/getting-started-faststore-v1-to-v4"
+
+[[redirects]]
+force = true
+from = "/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users"
+status = 308
+to = "/docs/api-reference/authenticator-api#post-/api/authenticator/v1/storefront/users"
+
+[[redirects]]
+force = true
+from = "/docs/api-reference/vtex-id-api#put-/api/authenticator/v1/tenants/features/-name-"
+status = 308
+to = "/docs/api-reference/authenticator-api#put-/api/authenticator/v1/tenants/features/-name-"
+
+[[redirects]]
+force = true
+from = "/docs/api-reference/vtex-id-api#patch-/api/authenticator/v1/tenants/features/-name-"
+status = 308
+to = "/docs/api-reference/authenticator-api#patch-/api/authenticator/v1/tenants/features/-name-"
+
+[[redirects]]
+force = true
+from = "/docs/api-reference/vtex-id-api#delete-/api/authenticator/v1/tenants/features/-name-"
+status = 308
+to = "/docs/api-reference/authenticator-api#delete-/api/authenticator/v1/tenants/features/-name-"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2448,3 +2448,21 @@ force = true
 from = "/docs/api-reference/vtex-id-api#delete-/api/authenticator/v1/tenants/features/-name-"
 status = 308
 to = "/docs/api-reference/authenticator-api#delete-/api/authenticator/v1/tenants/features/-name-"
+
+[[redirects]]
+force = true
+from = "/docs/api-reference/organization-units-api#post-/api/organization-units/v1/-organizationUnitId-/users"
+status = 308
+to = "/docs/api-reference/organization-units-api#post-/api/vtexid/organization-units/-organizationUnitId-/users"
+
+[[redirects]]
+force = true
+from = "/docs/api-reference/organization-units-api#delete-/api/organization-units/v1/-organizationUnitId-/users"
+status = 308
+to = "/docs/api-reference/organization-units-api#delete-/api/vtexid/organization-units/-organizationUnitId-/users"
+
+[[redirects]]
+force = true
+from = "/docs/api-reference/organization-units-api#get-/api/organization-units/v1/-organizationUnitId-/users"
+status = 308
+to = "/docs/api-reference/organization-units-api#get-/api/vtexid/organization-units/-organizationUnitId-/users"

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -11368,7 +11368,7 @@
                   "type": "openapi",
                   "method": "POST",
                   "origin": "",
-                  "endpoint": "/api/organization-units/v1/-organizationUnitId-/users",
+                  "endpoint": "/api/vtexid/organization-units/-organizationUnitId-/users",
                   "children": []
                 },
                 {
@@ -11377,7 +11377,7 @@
                   "type": "openapi",
                   "method": "DELETE",
                   "origin": "",
-                  "endpoint": "/api/organization-units/v1/-organizationUnitId-/users",
+                  "endpoint": "/api/vtexid/organization-units/-organizationUnitId-/users",
                   "children": []
                 },
                 {
@@ -11386,7 +11386,7 @@
                   "type": "openapi",
                   "method": "GET",
                   "origin": "",
-                  "endpoint": "/api/organization-units/v1/-organizationUnitId-/users",
+                  "endpoint": "/api/vtexid/organization-units/-organizationUnitId-/users",
                   "children": []
                 },
                 {
@@ -14426,15 +14426,6 @@
               "type": "category",
               "children": [
                 {
-                  "name": "Create storefront user with username",
-                  "slug": "vtex-id-api",
-                  "type": "openapi",
-                  "method": "POST",
-                  "origin": "",
-                  "endpoint": "/api/authenticator/v1/storefront/users",
-                  "children": []
-                },
-                {
                   "name": "Get storefront user by identifier",
                   "slug": "vtex-id-api",
                   "type": "openapi",
@@ -14582,6 +14573,64 @@
                 {
                   "name": "Delete password migration configuration",
                   "slug": "vtex-id-api",
+                  "type": "openapi",
+                  "method": "DELETE",
+                  "origin": "",
+                  "endpoint": "/api/authenticator/v1/tenants/features/{name}",
+                  "children": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Authenticator",
+          "slug": "authenticator-api",
+          "origin": "",
+          "type": "openapi",
+          "children": [
+            {
+              "name": "Storefront users",
+              "slug": "authenticator-api-storefront-users",
+              "type": "category",
+              "children": [
+                {
+                  "name": "Create storefront user with username",
+                  "slug": "authenticator-api",
+                  "type": "openapi",
+                  "method": "POST",
+                  "origin": "",
+                  "endpoint": "/api/authenticator/v1/storefront/users",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": "Password migration",
+              "slug": "authenticator-api-password-migration",
+              "type": "category",
+              "children": [
+                {
+                  "name": "Upsert password migration configuration",
+                  "slug": "authenticator-api",
+                  "type": "openapi",
+                  "method": "PUT",
+                  "origin": "",
+                  "endpoint": "/api/authenticator/v1/tenants/features/{name}",
+                  "children": []
+                },
+                {
+                  "name": "Enable or disable password migration",
+                  "slug": "authenticator-api",
+                  "type": "openapi",
+                  "method": "PATCH",
+                  "origin": "",
+                  "endpoint": "/api/authenticator/v1/tenants/features/{name}",
+                  "children": []
+                },
+                {
+                  "name": "Delete password migration configuration",
+                  "slug": "authenticator-api",
                   "type": "openapi",
                   "method": "DELETE",
                   "origin": "",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -505,4 +505,5 @@ export const openapiMappings: { [key: string]: string } = {
   'VTEX - B2B Contracts API': 'b2b-contracts-api',
   'VTEX - B2B Password Migration Protocol': 'b2b-password-migration-protocol',
   'VTEX - User Rights API': 'user-rights-api',
+  'VTEX - Authenticator API': 'authenticator-api',
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds the new Authenticator API (split out of VTEX ID API) to devportal:

- `src/utils/constants.ts`: `openapiMappings` entry for `VTEX - Authenticator API` -> `authenticator-api`.
- `public/navigation.json`: splits the storefront user creation and password migration endpoints out of the VTEX ID node into a new Authenticator node.
- `netlify.toml`: adds 308 redirects from the old `vtex-id-api` anchors to the new `authenticator-api` ones for the moved endpoints.

#### What problem is this solving?

B2B Buyer Portal stores have been wrongfully using VTEX ID API endpoints to provision users. These flows should only use the Authenticator API. Per the Identity EM's suggestion, Authenticator API endpoints are now documented separately from the VTEX ID API.

Tracked under epic [EDU-19218](https://vtex-dev.atlassian.net/browse/EDU-19218) / Jira: [EDU-19221](https://vtex-dev.atlassian.net/browse/EDU-19221).

Companion changes:
- openapi-schemas: new Authenticator API spec — [PR #1752](https://github.com/vtex/openapi-schemas/pull/1752)
- dev-portal-content: B2B guide docs updated — [PR #2908](https://github.com/vtexdocs/dev-portal-content/pull/2908)

#### How should this be manually tested?

Visit `/docs/api-reference/authenticator-api` and confirm the storefront user creation and password migration endpoints render correctly. Visit an old anchor like `/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users` and confirm it redirects to the new Authenticator API page/anchor.

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.