### PR TITLE
EDU-19229: add redirect for fastcheckout to buyer portal checkout

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2424,3 +2424,9 @@ force = true
 from = "/docs/guides/faststore/getting-started-faststore-v1-to-v3"
 status = 308
 to = "/docs/guides/faststore/getting-started-faststore-v1-to-v4"
+
+[[redirects]]
+force = true
+from = "/docs/guides/fastcheckout-setting-up"
+status = 308
+to = "/docs/guides/setting-up-buyer-portal-checkout"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2430,6 +2430,9 @@ force = true
 from = "/docs/guides/fastcheckout-setting-up"
 status = 308
 to = "/docs/guides/setting-up-buyer-portal-checkout"
+
+[[redirects]]
+force = true
 from = "/docs/api-reference/vtex-id-api#post-/api/authenticator/v1/storefront/users"
 status = 308
 to = "/docs/api-reference/authenticator-api#post-/api/authenticator/v1/storefront/users"


### PR DESCRIPTION
Added a new redirect rule to handle the FastCheckout to Buyer Portal checkout migration. This ensures URLs pointing to the old FastCheckout documentation are properly redirected to the new Buyer Portal checkout guide.

## Related Task

[EDU-19229](https://vtex-dev.atlassian.net/browse/EDU-19229)
