### PR TITLE
EDU-19158: rename tradename nav slug and add redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2472,3 +2472,9 @@ force = true
 from = "/docs/api-reference/organization-units-api#get-/api/organization-units/v1/-organizationUnitId-/users"
 status = 308
 to = "/docs/api-reference/organization-units-api#get-/api/vtexid/organization-units/-organizationUnitId-/users"
+
+[[redirects]]
+force = true
+from = "/docs/guides/how-to-configure-tradename-to-use-in-the-organization-search-field"
+status = 308
+to = "/docs/guides/configure-tradename"

--- a/public/navigation.json
+++ b/public/navigation.json
@@ -2372,7 +2372,7 @@
                     },
                     {
                       "name": "How to configure tradeName to use in the organization search field",
-                      "slug": "how-to-configure-tradename-to-use-in-the-organization-search-field",
+                      "slug": "configure-tradename",
                       "origin": "",
                       "type": "markdown",
                       "children": []


### PR DESCRIPTION
## Summary

Points the "How to configure tradeName..." nav entry at the surviving article slug and adds a redirect for the removed duplicate.

## Changes

- Renamed the nav entry slug in `public/navigation.json` from `how-to-configure-tradename-to-use-in-the-organization-search-field` to `configure-tradename`.
- Added a 308 redirect in `netlify.toml` from the old slug to the new one.

## Why

`dev-portal-content` had two byte-for-byte identical articles about configuring `tradeName`. The nav was pointing at the longer-slugged duplicate, which is being removed in a companion PR on `vtexdocs/dev-portal-content`. This PR updates the nav to point at the surviving `configure-tradename` slug and preserves the old URL via redirect.

## Related Task

[EDU-19158](https://vtex-dev.atlassian.net/browse/EDU-19158)
