### PR TITLE
chore(navigation.json): add authenticator first login endpoints and guide

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -2308,6 +2308,13 @@
                   "children": []
                 },
                 {
+                  "name": "B2B first login",
+                  "slug": "b2b-first-login",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
                   "name": "B2B password migration",
                   "slug": "b2b-password-migration",
                   "origin": "",
@@ -14581,6 +14588,40 @@
                   "method": "POST",
                   "origin": "",
                   "endpoint": "/api/authenticator/v1/storefront/users",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "name": "First login",
+              "slug": "authenticator-api-first-login",
+              "type": "category",
+              "children": [
+                {
+                  "name": "Start login attempt",
+                  "slug": "authenticator-api",
+                  "type": "openapi",
+                  "method": "POST",
+                  "origin": "",
+                  "endpoint": "/api/authenticator/v1/pub/authentication/start",
+                  "children": []
+                },
+                {
+                  "name": "Sign in",
+                  "slug": "authenticator-api",
+                  "type": "openapi",
+                  "method": "POST",
+                  "origin": "",
+                  "endpoint": "/api/authenticator/v1/bff/storefront/signin",
+                  "children": []
+                },
+                {
+                  "name": "Set password",
+                  "slug": "authenticator-api",
+                  "type": "openapi",
+                  "method": "POST",
+                  "origin": "",
+                  "endpoint": "/api/authenticator/v1/pub/authentication/classic/setpassword",
                   "children": []
                 }
               ]


### PR DESCRIPTION
## Summary
- Adds the "First login" category (Start login attempt, Sign in, Set password) under the Authenticator API reference section.
- Adds the new "B2B first login" guide entry under B2B Buyer Portal guides.

## Test plan
- [x] `navigation.json` validated as well-formed JSON
- [ ] Preview renders new nav entries correctly