### PR TITLE
docs: add login page troubleshooting guide to navigation

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -19495,6 +19495,13 @@
               "children": []
             },
             {
+              "name": "My store's login page is not displaying correctly",
+              "slug": "my-store-login-page-is-not-displaying-correctly",
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
               "name": "UTMs are not being applied to the cart at Checkout",
               "slug": "utms-are-not-being-applied-to-the-cart-at-checkout",
               "origin": "",


### PR DESCRIPTION
## Summary
- Adds "My store's login page is not displaying correctly" to `public/navigation.json`, under Checkout and shopping experience, alongside the other checkout troubleshooting articles.
- Corresponds to the new article added in vtexdocs/dev-portal-content#2946.

## Test plan
- [ ] Confirm the entry renders in the Troubleshooting sidebar under Checkout and shopping experience
- [ ] Confirm the slug (`my-store-login-page-is-not-displaying-correctly`) matches the article once vtexdocs/dev-portal-content#2946 merges