### PR TITLE
EDU-19147: Move Checkout Extensibility nav entries under B2B Buyer Portal

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -941,28 +941,6 @@
               ]
             },
             {
-              "name": "Custom checkout fields settings",
-              "slug": "custom-checkout-fields-settings",
-              "origin": "",
-              "type": "markdown",
-              "children": [
-                {
-                  "name": "Custom fields integration",
-                  "slug": "custom-fields-integration",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "Default values integration",
-                  "slug": "default-values-integration",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                }
-              ]
-            },
-            {
               "name": "Discounts",
               "slug": "discounts",
               "origin": "",
@@ -1273,119 +1251,6 @@
                 {
                   "name": "Get sellers by region or address",
                   "slug": "get-sellers-by-region-or-address",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "name": "Buyer Portal Checkout Extensibility",
-              "slug": "buyer-portal-checkout-extensibility",
-              "origin": "",
-              "type": "markdown",
-              "children": [
-                {
-                  "name": "Checkout extension points",
-                  "slug": "checkout-extension-points",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "Setting up Buyer Portal Checkout",
-                  "slug": "setting-up-buyer-portal-checkout",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "Getting started with Checkout extensions",
-                  "slug": "getting-started-with-checkout-extensions",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "Deploying Checkout extensions",
-                  "slug": "deploying-checkout-extensions",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "Using CSS in Checkout extensions",
-                  "slug": "using-css-in-checkout-extensions",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "CSS variables in Checkout extensions",
-                  "slug": "css-variables-in-checkout-extensions",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "Data layer and data fetching in Checkout extensions",
-                  "slug": "data-layer-and-data-fetching-in-checkout-extensions",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "Checkout CLI",
-                  "slug": "checkout-cli",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "CartItem type",
-                  "slug": "cartitem-type",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "useCart hook",
-                  "slug": "usecart-hook",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "useCartItem hook",
-                  "slug": "usecartitem-hook",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "useCartPunchout hook",
-                  "slug": "usecartpunchout-hook",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "useRedirect hook",
-                  "slug": "useredirect-hook",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "useSettings hook",
-                  "slug": "usesettings-hook",
-                  "origin": "",
-                  "type": "markdown",
-                  "children": []
-                },
-                {
-                  "name": "useExtension hook",
-                  "slug": "useextension-hook",
                   "origin": "",
                   "type": "markdown",
                   "children": []
@@ -2362,6 +2227,141 @@
                   "origin": "",
                   "type": "markdown",
                   "children": []
+                },
+                {
+                  "name": "Buyer Portal Checkout Extensibility",
+                  "slug": "buyer-portal-checkout-extensibility",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": [
+                    {
+                      "name": "Checkout extension points",
+                      "slug": "checkout-extension-points",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "Setting up Buyer Portal Checkout",
+                      "slug": "setting-up-buyer-portal-checkout",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "Getting started with Checkout extensions",
+                      "slug": "getting-started-with-checkout-extensions",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "Deploying Checkout extensions",
+                      "slug": "deploying-checkout-extensions",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "Using CSS in Checkout extensions",
+                      "slug": "using-css-in-checkout-extensions",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "CSS variables in Checkout extensions",
+                      "slug": "css-variables-in-checkout-extensions",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "Data layer and data fetching in Checkout extensions",
+                      "slug": "data-layer-and-data-fetching-in-checkout-extensions",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "Checkout CLI",
+                      "slug": "checkout-cli",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "CartItem type",
+                      "slug": "cartitem-type",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "useCart hook",
+                      "slug": "usecart-hook",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "useCartItem hook",
+                      "slug": "usecartitem-hook",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "useCartPunchout hook",
+                      "slug": "usecartpunchout-hook",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "useRedirect hook",
+                      "slug": "useredirect-hook",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "useSettings hook",
+                      "slug": "usesettings-hook",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "useExtension hook",
+                      "slug": "useextension-hook",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    }
+                  ]
+                },
+                {
+                  "name": "Custom checkout fields settings",
+                  "slug": "custom-checkout-fields-settings",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": [
+                    {
+                      "name": "Custom fields integration",
+                      "slug": "custom-fields-integration",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    },
+                    {
+                      "name": "Default values integration",
+                      "slug": "default-values-integration",
+                      "origin": "",
+                      "type": "markdown",
+                      "children": []
+                    }
+                  ]
                 }
               ]
             },


### PR DESCRIPTION
Moves the "Buyer Portal Checkout Extensibility" and "Custom checkout fields settings" nav categories from `Guides > Checkout` to `Guides > B2B > B2B Buyer Portal`, matching the corresponding content-repo move in `dev-portal-content`.

## Related Task

[EDU-19147](https://vtex-dev.atlassian.net/browse/EDU-19147)
