### PR TITLE
chore: add search analytics tracking guides to Search category nav

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -2855,6 +2855,20 @@
               "origin": "",
               "type": "markdown",
               "children": []
+            },
+            {
+              "name": "Tracking search analytics events in headless web stores",
+              "slug": "tracking-search-analytics-events-in-headless-web-stores",
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
+              "name": "Tracking search analytics events in mobile apps",
+              "slug": "tracking-search-analytics-events-in-mobile-apps",
+              "origin": "",
+              "type": "markdown",
+              "children": []
             }
           ]
         },


### PR DESCRIPTION
## Summary
- Adds the two new Search category guides (tracking Intelligent Search analytics events in headless web stores and in mobile apps) to `public/navigation.json`.
- Depends on vtexdocs/dev-portal-content#2962 and #2963 for the pages to exist.
- Related to [EDU-19325](https://vtex-dev.atlassian.net/browse/EDU-19325).

## Test plan
- [ ] Confirm both entries render in the Search category sidebar once merged and the content PRs are live.