### PR TITLE
chore: add product recommendations to nav, fix search app slug typos

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -2879,6 +2879,13 @@
           "type": "category",
           "children": [
             {
+              "name": "Product recommendations",
+              "slug": "product-recommendations",
+              "origin": "",
+              "type": "markdown",
+              "children": []
+            },
+            {
               "name": "Integrating product recommendations in headless or FastStore web stores",
               "slug": "integrating-product-recommendations-in-headless-or-faststore-web-stores",
               "origin": "",
@@ -16312,7 +16319,7 @@
           "children": [
             {
               "name": "My Account",
-              "slug": "vtex.mmy-account",
+              "slug": "apps/vtex.my-account",
               "origin": "",
               "type": "markdown",
               "children": [
@@ -16530,7 +16537,7 @@
               "name": "Cart and checkout",
               "slug": "guides/cart-and-checkout",
               "origin": "",
-              "type": "markdown",
+              "type": "category",
               "children": [
                 {
                   "name": "Add to cart button",
@@ -16697,7 +16704,7 @@
               "children": [
                 {
                   "name": "Autocomplete",
-                  "slug": "apps/vtex.vtex.search/autocomplete",
+                  "slug": "apps/vtex.search/autocomplete",
                   "origin": "",
                   "type": "markdown",
                   "children": []
@@ -16731,8 +16738,15 @@
                   "children": []
                 },
                 {
+                  "name": "Recommendation Shelf",
+                  "slug": "apps/vtex.recommendation-shelf",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
                   "name": "Suggestions",
-                  "slug": "apps/vtex.vtex.search/suggestions",
+                  "slug": "apps/vtex.search/suggestions",
                   "origin": "",
                   "type": "markdown",
                   "children": []
@@ -16807,7 +16821,7 @@
               "name": "Product display",
               "slug": "guides/product-display",
               "origin": "",
-              "type": "markdown",
+              "type": "category",
               "children": [
                 {
                   "name": "Product Customizer",


### PR DESCRIPTION
## Summary
- Add "Product recommendations" guide entry under Guides > Search > Recommendations (the overview page at `/docs/guides/product-recommendations` had no nav entry).
- Add "Recommendation Shelf" app under VTEX IO Apps > Store Framework > Navigation and search (alongside Search/Suggestions, since it's search-driven recommendation logic).
- Fix doubled `vtex.vtex.search` slugs on the Autocomplete and Suggestions app entries (should be `vtex.search`, matching DidYouMean's correct pattern).
- Fix `vtex.mmy-account` typo (doubled letter + missing `apps/` prefix) to `apps/vtex.my-account`.
- Change "Cart and checkout" and "Product display" node type from `markdown` to `category`, matching their sibling groupings (Layout and interaction patterns, Navigation and search, Store Components).

## Test plan
- [x] Validated `public/navigation.json` is well-formed JSON after each change.
- [ ] Confirm the fixed app slugs (`apps/vtex.search/autocomplete`, `apps/vtex.search/suggestions`, `apps/vtex.my-account`) resolve correctly on the live site.
- [ ] Confirm "Cart and checkout" and "Product display" render as expandable categories in the sidebar without a dead link.