### PR TITLE
feat(navigation.json): add missing release notes entries for August and September 2026

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -19834,6 +19834,21 @@
           "type": "category",
           "children": [
             {
+              "name": "September",
+              "slug": "september-2026",
+              "origin": "",
+              "type": "category",
+              "children": [
+                {
+                  "name": "VTEX Ads API: New endpoint for product results by campaign",
+                  "slug": "2026-09-02-vtex-ads-api-new-endpoint-for-product-results-by-campaign",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                }
+              ]
+            },
+            {
               "name": "August",
               "slug": "august-2026",
               "origin": "",
@@ -19854,8 +19869,22 @@
                   "children": []
                 },
                 {
+                  "name": "B2B Organizations GraphQL: optional status on create mutations",
+                  "slug": "2026-08-24-b2b-organizations-graphql-optional-status-on-create-mutations",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
                   "name": "FastStore Release Notes — Version 4.5.0",
                   "slug": "2026-08-10-faststore-release-notes-4-5-0",
+                  "origin": "",
+                  "type": "markdown",
+                  "children": []
+                },
+                {
+                  "name": "VTEX Ads API: Rate limit on Reports endpoints",
+                  "slug": "2026-08-04-vtex-ads-api-reports-rate-limit",
                   "origin": "",
                   "type": "markdown",
                   "children": []


### PR DESCRIPTION
## Summary

Registers three release notes that exist in `dev-portal-content` but were missing from the Developers Portal sidebar navigation.

## Changes

- Added a new `September` category (slug `september-2026`) under `Release Notes / 2026`, containing:
  - VTEX Ads API: New endpoint for product results by campaign (`2026-09-02-vtex-ads-api-new-endpoint-for-product-results-by-campaign`)
- Added two missing entries to the existing `August` category:
  - B2B Organizations GraphQL: optional status on create mutations (`2026-08-24-b2b-organizations-graphql-optional-status-on-create-mutations`)
  - VTEX Ads API: Rate limit on Reports endpoints (`2026-08-04-vtex-ads-api-reports-rate-limit`)

Both August entries were inserted so the section stays in reverse-chronological order: 08-25, 08-24 (VBase), 08-24 (B2B), 08-10, 08-04.

## Why

An audit of release notes published in the last two months found that these three articles had no navigation entry, so they were not reachable from the sidebar. Entry names and slugs were taken directly from each article's front matter `title` and `slug` in `dev-portal-content`.

## Key files affected

- `public/navigation.json`
