### PR TITLE
docs: add Authenticator user lookup endpoints to nav

### DIFF
--- a/public/navigation.json
+++ b/public/navigation.json
@@ -13350,6 +13350,24 @@
                   "origin": "",
                   "endpoint": "/api/authenticator/v1/storefront/users",
                   "children": []
+                },
+                {
+                  "name": "Get storefront user by user ID",
+                  "slug": "authenticator-api",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/api/authenticator/v1/users/-userId-",
+                  "children": []
+                },
+                {
+                  "name": "Get storefront user by identifier",
+                  "slug": "authenticator-api",
+                  "type": "openapi",
+                  "method": "GET",
+                  "origin": "",
+                  "endpoint": "/api/authenticator/v1/users/info",
+                  "children": []
                 }
               ]
             },


### PR DESCRIPTION
## Summary
- Adds two new entries under Authenticator > Storefront users:
  - `GET /api/authenticator/v1/users/{userId}` — Get storefront user by user ID
  - `GET /api/authenticator/v1/users/info` — Get storefront user by identifier
- Matches the routes documented in vtex/openapi-schemas#1777

Ref: EDU-19489

## Test plan
- [x] Validated navigation.json is valid JSON